### PR TITLE
Email duplicate fixes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/controller/admin/BookerDetailAdminConfigController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/controller/admin/BookerDetailAdminConfigController.kt
@@ -414,5 +414,5 @@ class BookerDetailConfigController(
     @PathVariable(value = "emailAddress", required = true)
     @NotBlank
     emailAddress: String,
-  ): BookerDto = bookerDetailsService.getBookerByEmail(emailAddress)
+  ): List<BookerDto> = bookerDetailsService.getBookerByEmail(emailAddress)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/BookerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/BookerRepository.kt
@@ -13,7 +13,7 @@ interface BookerRepository : JpaRepository<Booker, Long> {
 
   fun findByReference(reference: String): Booker?
 
-  fun findByEmailIgnoreCase(emailAddress: String): Booker?
+  fun findByEmailIgnoreCase(emailAddress: String): List<Booker>?
 
   fun findByEmailIgnoreCaseAndOneLoginSub(emailAddress: String, oneLoginSub: String): Booker?
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/BookerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/BookerRepository.kt
@@ -13,7 +13,7 @@ interface BookerRepository : JpaRepository<Booker, Long> {
 
   fun findByReference(reference: String): Booker?
 
-  fun findByEmailIgnoreCase(emailAddress: String): List<Booker>?
+  fun findAllByEmailIgnoreCase(emailAddress: String): List<Booker>?
 
   fun findByEmailIgnoreCaseAndOneLoginSub(emailAddress: String, oneLoginSub: String): Booker?
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/AuthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/AuthService.kt
@@ -29,6 +29,7 @@ class AuthService(
     return booker.reference
   }
 
+  // TODO: Should we log to application insights if either of the IF statement come true?
   private fun findByDetailedBookerSearch(createBookerAuthDetail: AuthDetailDto): Booker {
     val bookerViaOneLogin = bookerRepository.findByOneLoginSub(createBookerAuthDetail.oneLoginSub)
     if (bookerViaOneLogin != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/AuthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/AuthService.kt
@@ -39,7 +39,7 @@ class AuthService(
       return bookerViaOneLogin
     }
 
-    val bookerViaEmail = bookerRepository.findByEmailIgnoreCase(createBookerAuthDetail.email)?.any() ?: false
+    val bookerViaEmail = bookerRepository.findAllByEmailIgnoreCase(createBookerAuthDetail.email)?.any() ?: false
     if (bookerViaEmail) {
       LOG.warn("Found existing booker(s) via email search ${createBookerAuthDetail.email} but with different one login subs. Creating new booker for email ${createBookerAuthDetail.email}")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsService.kt
@@ -38,7 +38,7 @@ class BookerDetailsService(
   @Transactional
   fun create(emailAddress: String): BookerDto {
     LOG.info("Enter BookerDetailsService create")
-    bookerRepository.findByEmailIgnoreCase(emailAddress)?.let {
+    bookerRepository.findAllByEmailIgnoreCase(emailAddress)?.let {
       LOG.warn("Found existing user for given email - {}", emailAddress)
     }
 
@@ -217,7 +217,7 @@ class BookerDetailsService(
   private fun getBooker(bookerReference: String): Booker = bookerRepository.findByReference(bookerReference) ?: throw BookerNotFoundException("Booker for reference : $bookerReference not found")
 
   private fun findBookersByEmail(emailAddress: String): List<Booker> {
-    val foundBookers = bookerRepository.findByEmailIgnoreCase(emailAddress)
+    val foundBookers = bookerRepository.findAllByEmailIgnoreCase(emailAddress)
     if (foundBookers.isNullOrEmpty()) {
       throw BookerNotFoundException("Booker(s) for email : $emailAddress not found")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/AuthDetailsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/AuthDetailsControllerTest.kt
@@ -57,7 +57,7 @@ class AuthDetailsControllerTest : IntegrationTestBase() {
     assertThat(updatedPilotBooker!!.oneLoginSub).isEqualTo(authDetailsDto.oneLoginSub)
 
     verify(bookerRepositorySpy, times(1)).findByEmailIgnoreCaseAndOneLoginSub(authDetailsDto.email, authDetailsDto.oneLoginSub)
-    verify(bookerRepositorySpy, times(1)).findByEmailIgnoreCase(authDetailsDto.email)
+    verify(bookerRepositorySpy, times(1)).findAllByEmailIgnoreCase(authDetailsDto.email)
     verify(bookerRepositorySpy, times(1)).findByOneLoginSub(authDetailsDto.oneLoginSub)
     verify(bookerRepositorySpy, times(1)).saveAndFlush(any())
     verify(bookerAuditRepositorySpy, times(1)).saveAndFlush(any<BookerAudit>())
@@ -91,7 +91,7 @@ class AuthDetailsControllerTest : IntegrationTestBase() {
     val reference = getReference(responseSpec)
     assertThat(reference).isEqualTo(booker.reference)
     verify(bookerRepositorySpy, times(1)).findByEmailIgnoreCaseAndOneLoginSub(authDetailsDto.email, authDetailsDto.oneLoginSub)
-    verify(bookerRepositorySpy, times(0)).findByEmailIgnoreCase(authDetailsDto.email)
+    verify(bookerRepositorySpy, times(0)).findAllByEmailIgnoreCase(authDetailsDto.email)
     verify(bookerRepositorySpy, times(0)).findByOneLoginSub(authDetailsDto.oneLoginSub)
 
     verify(bookerAuditRepositorySpy, times(0)).saveAndFlush(any<BookerAudit>())
@@ -117,7 +117,7 @@ class AuthDetailsControllerTest : IntegrationTestBase() {
     val reference = getReference(responseSpec)
     assertThat(reference).isEqualTo(booker.reference)
     verify(bookerRepositorySpy, times(1)).findByEmailIgnoreCaseAndOneLoginSub(authDetailsDto.email, authDetailsDto.oneLoginSub)
-    verify(bookerRepositorySpy, times(0)).findByEmailIgnoreCase(authDetailsDto.email)
+    verify(bookerRepositorySpy, times(0)).findAllByEmailIgnoreCase(authDetailsDto.email)
     verify(bookerRepositorySpy, times(0)).findByOneLoginSub(authDetailsDto.oneLoginSub)
     verify(bookerAuditRepositorySpy, times(0)).saveAndFlush(any<BookerAudit>())
     verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
@@ -153,7 +153,7 @@ class AuthDetailsControllerTest : IntegrationTestBase() {
 
     val oldBookerDetails = bookerRepository.findByEmailIgnoreCaseAndOneLoginSub(authDetailsDto.email, oldSub)
     assertThat(reference).isNotEqualTo(oldBookerDetails!!.reference)
-    verify(bookerRepositorySpy, times(1)).findByEmailIgnoreCase(authDetailsDto.email)
+    verify(bookerRepositorySpy, times(1)).findAllByEmailIgnoreCase(authDetailsDto.email)
     verify(bookerAuditRepositorySpy, times(1)).saveAndFlush(any<BookerAudit>())
     verify(telemetryClientSpy, times(1)).trackEvent(
       BOOKER_CREATED.telemetryEventName,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/AuthDetailsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/AuthDetailsControllerTest.kt
@@ -169,7 +169,7 @@ class AuthDetailsControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when booker exists with same sub but different sub email address the email address is updated with the new sub`() {
+  fun `when booker exists with same sub but different email address the email address is updated with the new sub`() {
     // Given
     val oldEmailAddress = emailAddress
     val newEmailAddress = "test1@example.com"
@@ -196,7 +196,6 @@ class AuthDetailsControllerTest : IntegrationTestBase() {
     val newBookerDetails = bookerRepository.findByEmailIgnoreCaseAndOneLoginSub(newEmailAddress, oneLoginSub)
     assertThat(newBookerDetails).isNotNull
     assertThat(reference).isEqualTo(newBookerDetails!!.reference)
-    verify(bookerRepositorySpy, times(1)).findByEmailIgnoreCase(authDetailsDto.email)
     verify(bookerRepositorySpy, times(1)).updateBookerEmailAddress(reference, authDetailsDto.email)
     verify(telemetryClientSpy, times(1)).trackEvent(
       UPDATE_BOOKER_EMAIL.telemetryEventName,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/BookerByEmailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/BookerByEmailTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration
 
+import com.fasterxml.jackson.core.type.TypeReference
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -49,7 +50,7 @@ class BookerByEmailTest : IntegrationTestBase() {
 
     // Then
     val returnResult = responseSpec.expectStatus().isOk.expectBody()
-    val booker = getResults(returnResult)
+    val booker = getResults(returnResult).first()
     assertThat(booker.permittedPrisoners).hasSize(3)
     assertThat(booker.permittedPrisoners[0].prisonerId).isEqualTo(prisoner1.prisonerId)
     assertThat(booker.permittedPrisoners[1].prisonerId).isEqualTo(prisoner2.prisonerId)
@@ -65,7 +66,7 @@ class BookerByEmailTest : IntegrationTestBase() {
       .expectBody()
       .jsonPath("$.userMessage").isEqualTo("Booker not found")
       .jsonPath("$.developerMessage")
-      .isEqualTo("Booker for email : invalid-email not found")
+      .isEqualTo("Booker(s) for email : invalid-email not found")
   }
 
   @Test
@@ -75,7 +76,7 @@ class BookerByEmailTest : IntegrationTestBase() {
     responseSpec.expectStatus().isForbidden
   }
 
-  private fun getResults(returnResult: WebTestClient.BodyContentSpec): BookerDto = objectMapper.readValue(returnResult.returnResult().responseBody, BookerDto::class.java)
+  private fun getResults(returnResult: WebTestClient.BodyContentSpec): List<BookerDto> = objectMapper.readValue(returnResult.returnResult().responseBody, object : TypeReference<List<BookerDto>>() {})
 
   fun getBookerByEmail(
     webTestClient: WebTestClient,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/CreateBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/CreateBookerTest.kt
@@ -38,12 +38,12 @@ class CreateBookerTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isCreated
 
-    val createdEntity = bookerRepository.findByEmailIgnoreCase(emailAddress)
+    val createdEntity = bookerRepository.findByEmailIgnoreCase(emailAddress)!!.first()
     assertThat(createdEntity).isNotNull
 
     val dto = getBookerDto(responseSpec)
     assertThat(dto.reference).hasSizeGreaterThan(9)
-    assertThat(dto.reference).isEqualTo(createdEntity!!.reference)
+    assertThat(dto.reference).isEqualTo(createdEntity.reference)
     assertThat(dto.oneLoginSub).isNull()
     assertThat(dto.email).isEqualTo(emailAddress)
     assertThat(dto.permittedPrisoners).isEmpty()
@@ -64,7 +64,7 @@ class CreateBookerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when booker does exist then exception is thrown`() {
+  fun `when email exists in our system, it still allows registration and generates new booker with new sub`() {
     // Given
     val emailAddress = "aled@aled.com"
 
@@ -78,7 +78,7 @@ class CreateBookerTest : IntegrationTestBase() {
     val responseSpec = callCreateBooker(bookerConfigServiceRoleHttpHeaders, createBookerDto)
 
     // Then
-    assertError(responseSpec, "Booker already exists", "The given email - $emailAddress already exists", BAD_REQUEST)
+    responseSpec.expectStatus().isCreated
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/CreateBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/CreateBookerTest.kt
@@ -38,7 +38,7 @@ class CreateBookerTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isCreated
 
-    val createdEntity = bookerRepository.findByEmailIgnoreCase(emailAddress)!!.first()
+    val createdEntity = bookerRepository.findAllByEmailIgnoreCase(emailAddress)!!.first()
     assertThat(createdEntity).isNotNull
 
     val dto = getBookerDto(responseSpec)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/IntegrationTestBase.kt
@@ -104,6 +104,7 @@ abstract class IntegrationTestBase {
 
   @BeforeEach
   fun resetStubs() {
+    entityHelper.deleteAll()
     prisonOffenderSearchMockServer.resetAll()
     visitSchedulerMockServer.resetAll()
   }


### PR DESCRIPTION
## What does this PR do?

Re-works how we process a booker if they attempt to register with a different combination of "email" and "one login sub". 

1. attempt to find booker by matching sub and email in DB and return them.

2. If this fails:
- 2a. if one login sub is found, with different email -> update email and return booker.
- 2b. if email is found, with different one login sub -> log a warning && create a new booker
- 2c.if neither -> new booker