### PR TITLE
VB-6616 - Add prisoner contact updated event to auto approval checks

### DIFF
--- a/helm_deploy/hmpps-prison-visit-booker-registry/values.yaml
+++ b/helm_deploy/hmpps-prison-visit-booker-registry/values.yaml
@@ -43,6 +43,10 @@ generic-service:
       HMPPS_SQS_QUEUES_PRISONVISITSCREATECONTACTEVENT_QUEUE_NAME: "sqs_queue_name"
     sqs-prison-visits-create-contact-event-dlq-secret:
       HMPPS_SQS_QUEUES_PRISONVISITSCREATECONTACTEVENT_DLQ_NAME: "sqs_queue_name"
+    sqs-prison-visits-booker-events-secret:
+      HMPPS_SQS_QUEUES_PRISONVISITSBOOKEREVENTS_QUEUE_NAME: "sqs_queue_name"
+    sqs-prison-visits-booker-events-dlq-secret:
+      HMPPS_SQS_QUEUES_PRISONVISITSBOOKEREVENTS_DLQ_NAME: "sqs_queue_name"
     hmpps-prison-visit-booker-registry:
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
@@ -59,7 +63,6 @@ generic-service:
   retryDlqCronjob:
     enabled: true
     retryDlqSchedule: "*/15 * * * *" # Override to every 15 minutes for the DLQ retry. Allows for downstream API issues to resolve before retrying.
-
 
 generic-prometheus-alerts:
   targetApplication: hmpps-prison-visit-booker-registry

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -28,5 +28,7 @@ generic-prometheus-alerts:
   sqsAlertsQueueNames:
     - "book-a-prison-visit-dev-hmpps_prison_visits_create_contact_event_queue"
     - "book-a-prison-visit-dev-hmpps_prison_visits_create_contact_event_dlq"
+    - "book-a-prison-visit-dev-hmpps_prison_visits_booker_events_queue"
+    - "book-a-prison-visit-dev-hmpps_prison_visits_booker_events_dlq"
   sqsAlertsOldestThreshold: 1
   sqsAlertsTotalMessagesThreshold: 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/enums/DomainEventTypes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/enums/DomainEventTypes.kt
@@ -2,4 +2,5 @@ package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums
 
 enum class DomainEventTypes(val value: String) {
   PRISONER_CONTACT_CREATED_EVENT("contacts-api.prisoner-contact.created"),
+  PRISONER_CONTACT_UPDATED_EVENT("contacts-api.prisoner-contact.updated"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/DomainEventListenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/DomainEventListenerService.kt
@@ -5,19 +5,19 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.DomainEventTypes
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.DomainEvent
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.handlers.PrisonerContactCreatedEventHandler
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.handlers.PrisonerContactCreatedUpdatedEventHandler
 
 @Service
-class DomainEventListenerService(val prisonerContactCreatedEventHandler: PrisonerContactCreatedEventHandler) {
+class DomainEventListenerService(val prisonerContactCreatedUpdatedEventHandler: PrisonerContactCreatedUpdatedEventHandler) {
   companion object {
     private val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
   fun handleMessage(domainEvent: DomainEvent) {
     when (domainEvent.eventType) {
-      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value -> {
-        LOG.info("Received domain event - {}", domainEvent)
-        prisonerContactCreatedEventHandler.handle(domainEvent)
+      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value, DomainEventTypes.PRISONER_CONTACT_UPDATED_EVENT.value -> {
+        LOG.info("Received create / update prisoner contact domain event - {}", domainEvent)
+        prisonerContactCreatedUpdatedEventHandler.handle(domainEvent)
       }
       else -> {
         LOG.warn("Received unknown domain event - {}", domainEvent)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/DomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/DomainEventListener.kt
@@ -19,11 +19,11 @@ class DomainEventListener(
   @param:Value("\${domain-event-processing.enabled}") val domainEventProcessingEnabled: Boolean,
 ) {
   companion object {
-    const val PRISON_VISITS_CREATE_CONTACT_EVENT_QUEUE_CONFIG_KEY = "prisonvisitscreatecontactevent"
+    const val PRISON_VISITS_BOOKER_EVENTS_QUEUE_CONFIG_KEY = "prisonvisitsbookerevents"
     private val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @SqsListener(PRISON_VISITS_CREATE_CONTACT_EVENT_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy")
+  @SqsListener(PRISON_VISITS_BOOKER_EVENTS_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy")
   fun processMessage(sqsMessage: SQSMessage) {
     if (!domainEventProcessingEnabled) {
       LOG.debug("Domain event processing is disabled")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedUpdatedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedUpdatedEventHandler.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.additionalinfo.PrisonerContactCreatedAdditionalInfo
 
 @Service
-class PrisonerContactCreatedEventHandler(
+class PrisonerContactCreatedUpdatedEventHandler(
   @param:Qualifier("objectMapper")
   private val objectMapper: ObjectMapper,
   private val prisonerContactRegistryClient: PrisonerContactRegistryClient,
@@ -31,16 +31,16 @@ class PrisonerContactCreatedEventHandler(
     val contactId = domainEvent.personReference.identifiers.firstOrNull { it.type == Identifier.DPS_CONTACT_ID }?.value
     val relationshipId = objectMapper.readValue(domainEvent.additionalInformation, PrisonerContactCreatedAdditionalInfo::class.java).prisonerContactId
 
-    LOG.info("PrisonerContactCreatedEventHandler called for event ${domainEvent.eventType}, prisoner $prisonerId, contact $contactId and relationship (prisonerContactId) $relationshipId")
+    LOG.info("PrisonerContactCreatedUpdatedEventHandler called for event ${domainEvent.eventType}, prisoner $prisonerId, contact $contactId and relationship (prisonerContactId) $relationshipId")
 
     if (prisonerId == null || contactId == null) {
-      LOG.error("PrisonerContactCreatedEventHandler called for event ${domainEvent.eventType} with no prisonerId ($prisonerId) or contactId ($contactId), skipping processing of event")
+      LOG.error("PrisonerContactCreatedUpdatedEventHandler called for event ${domainEvent.eventType} with no prisonerId ($prisonerId) or contactId ($contactId), skipping processing of event")
       return
     }
 
     val requests = visitorRequestsService.getActiveVisitorRequestsByPrisonerId(prisonerId)
     if (requests.isEmpty()) {
-      LOG.info("PrisonerContactCreatedEventHandler - No visitor requests found for prisoner $prisonerId")
+      LOG.info("PrisonerContactCreatedUpdatedEventHandler - No visitor requests found for prisoner $prisonerId")
       return
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,6 +31,13 @@ hmpps:
         dlqMaxReceiveCount: 1
         visibilityTimeout: 1
 
+      prisonvisitsbookerevents:
+        queueName: sqs_hmpps_visits_booker_events_queue
+        dlqName: sqs_hmpps_visits_booker_events_dlq
+        subscribeTopicId: domainevents
+        dlqMaxReceiveCount: 1
+        visibilityTimeout: 1
+
     topics:
       domainevents:
         arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedUpdatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedUpdatedTest.kt
@@ -6,7 +6,8 @@ import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -19,9 +20,18 @@ import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.time.LocalDate
 
 @DisplayName("Test for Domain Event Prisoner Contact Created")
-class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
-  @Test
-  fun `when domain event 'prisoner contact created' is found, then it is processed`() {
+class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase() {
+  companion object {
+    @JvmStatic
+    fun events(): List<String> = listOf(
+      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      DomainEventTypes.PRISONER_CONTACT_UPDATED_EVENT.value,
+    )
+  }
+
+  @ParameterizedTest(name = "when domain event ''{0}'' is found, then it is processed")
+  @MethodSource("events")
+  fun `when domain event is found, then it is processed`(event: String) {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -29,7 +39,7 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     val contact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
 
     val domainEvent = createDomainEventJson(
-      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      event,
       createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
@@ -55,15 +65,16 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.AUTO_APPROVED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
   }
 
-  @Test
-  fun `when domain event 'prisoner contact created' is found but no visitor requests exist, then it is skipped`() {
+  @ParameterizedTest(name = "when domain event ''{0}'' is found but no visitor requests exist, then it is skipped")
+  @MethodSource("events")
+  fun `when domain event is found but no visitor requests exist, then it is skipped`() {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -87,14 +98,15 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     verify(prisonerContactRegistryClientSpy, times(0)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
   }
 
-  @Test
-  fun `when domain event 'prisoner contact created' is found but contact is not Social, then it is skipped`() {
+  @ParameterizedTest(name = "when domain event ''{0}'' is found but contact is not Social, then it is skipped")
+  @MethodSource("events")
+  fun `when domain event is found but contact is not Social, then it is skipped`() {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -128,15 +140,16 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
   }
 
-  @Test
-  fun `when domain event 'prisoner contact created' is found but no requests are in status REQUESTED, then it is skipped`() {
+  @ParameterizedTest(name = "when domain event ''{0}'' is found but no requests are in status REQUESTED, then it is skipped")
+  @MethodSource("events")
+  fun `when domain event is found but no requests are in status REQUESTED, then it is skipped`() {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -170,15 +183,16 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REJECTED)
     verify(prisonerContactRegistryClientSpy, times(0)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
   }
 
-  @Test
-  fun `when domain event 'prisoner contact created' is found but relationship is not found on prisoner-contact-registry, then it is skipped`() {
+  @ParameterizedTest(name = "when domain event ''{0}'' is found but relationship is not found on prisoner-contact-registry, then it is skipped")
+  @MethodSource("events")
+  fun `when domain event is found but relationship is not found on prisoner-contact-registry, then it is skipped`() {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -211,7 +225,7 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedUpdatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedUpdatedTest.kt
@@ -74,7 +74,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
 
   @ParameterizedTest(name = "when domain event ''{0}'' is found but no visitor requests exist, then it is skipped")
   @MethodSource("events")
-  fun `when domain event is found but no visitor requests exist, then it is skipped`() {
+  fun `when domain event is found but no visitor requests exist, then it is skipped`(event: String) {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -82,7 +82,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     val contact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
 
     val domainEvent = createDomainEventJson(
-      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      event,
       createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
@@ -106,7 +106,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
 
   @ParameterizedTest(name = "when domain event ''{0}'' is found but contact is not Social, then it is skipped")
   @MethodSource("events")
-  fun `when domain event is found but contact is not Social, then it is skipped`() {
+  fun `when domain event is found but contact is not Social, then it is skipped`(event: String) {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -114,7 +114,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     val contact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "O")
 
     val domainEvent = createDomainEventJson(
-      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      event,
       createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
@@ -149,7 +149,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
 
   @ParameterizedTest(name = "when domain event ''{0}'' is found but no requests are in status REQUESTED, then it is skipped")
   @MethodSource("events")
-  fun `when domain event is found but no requests are in status REQUESTED, then it is skipped`() {
+  fun `when domain event is found but no requests are in status REQUESTED, then it is skipped`(event: String) {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -157,7 +157,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     val contact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
 
     val domainEvent = createDomainEventJson(
-      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      event,
       createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
@@ -192,14 +192,14 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
 
   @ParameterizedTest(name = "when domain event ''{0}'' is found but relationship is not found on prisoner-contact-registry, then it is skipped")
   @MethodSource("events")
-  fun `when domain event is found but relationship is not found on prisoner-contact-registry, then it is skipped`() {
+  fun `when domain event is found but relationship is not found on prisoner-contact-registry, then it is skipped`(event: String) {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
     val relationshipId = 9876L
 
     val domainEvent = createDomainEventJson(
-      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      event,
       createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedUpdatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedUpdatedTest.kt
@@ -40,7 +40,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
 
     val domainEvent = createDomainEventJson(
       event,
-      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )
@@ -83,7 +83,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
 
     val domainEvent = createDomainEventJson(
       event,
-      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )
@@ -115,7 +115,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
 
     val domainEvent = createDomainEventJson(
       event,
-      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )
@@ -158,7 +158,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
 
     val domainEvent = createDomainEventJson(
       event,
-      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )
@@ -200,7 +200,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
 
     val domainEvent = createDomainEventJson(
       event,
-      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.DomainEv
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.DomainEventListener
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.DomainEventListener.Companion.PRISON_VISITS_CREATE_CONTACT_EVENT_QUEUE_CONFIG_KEY
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.additionalinfo.PrisonerContactCreatedAdditionalInfo
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.handlers.PrisonerContactCreatedEventHandler
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.handlers.PrisonerContactCreatedUpdatedEventHandler
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
@@ -95,7 +95,7 @@ abstract class EventsIntegrationTestBase {
   protected lateinit var domainEventListenerServiceSpy: DomainEventListenerService
 
   @MockitoSpyBean
-  protected lateinit var prisonerContactCreatedEventHandlerSpy: PrisonerContactCreatedEventHandler
+  protected lateinit var prisonerContactCreatedUpdatedEventHandlerSpy: PrisonerContactCreatedUpdatedEventHandler
 
   @MockitoSpyBean
   protected lateinit var visitorRequestsRepositorySpy: VisitorRequestsRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
@@ -161,7 +161,7 @@ abstract class EventsIntegrationTestBase {
   }
     """.trimIndent().replace("\n", "").replace("  ", "")
 
-  fun createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId: Long): String = TestObjectMapper.mapper
+  fun createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId: Long): String = TestObjectMapper.mapper
     .writeValueAsString(PrisonerContactCreatedAdditionalInfo(prisonerContactId = prisonerContactId))
 
   fun createBooker(oneLoginSub: String, emailAddress: String): Booker {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
@@ -30,7 +30,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.VisitorRequestsRepository
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.DomainEventListenerService
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.DomainEventListener
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.DomainEventListener.Companion.PRISON_VISITS_CREATE_CONTACT_EVENT_QUEUE_CONFIG_KEY
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.DomainEventListener.Companion.PRISON_VISITS_BOOKER_EVENTS_QUEUE_CONFIG_KEY
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.additionalinfo.PrisonerContactCreatedAdditionalInfo
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.handlers.PrisonerContactCreatedUpdatedEventHandler
 import uk.gov.justice.hmpps.sqs.HmppsQueue
@@ -74,16 +74,16 @@ abstract class EventsIntegrationTestBase {
 
   internal val topic by lazy { hmppsQueueService.findByTopicId("domainevents") as HmppsTopic }
 
-  internal val prisonVisitsCreateContactEventQueue by lazy {
+  internal val prisonVisitsBookerEventsQueue by lazy {
     hmppsQueueService.findByQueueId(
-      PRISON_VISITS_CREATE_CONTACT_EVENT_QUEUE_CONFIG_KEY,
+      PRISON_VISITS_BOOKER_EVENTS_QUEUE_CONFIG_KEY,
     ) as HmppsQueue
   }
 
-  internal val domainEventsSqsClient by lazy { prisonVisitsCreateContactEventQueue.sqsClient }
-  internal val domainEventsSqsDlqClient by lazy { prisonVisitsCreateContactEventQueue.sqsDlqClient }
-  internal val domainEventsQueueUrl by lazy { prisonVisitsCreateContactEventQueue.queueUrl }
-  internal val domainEventsDlqUrl by lazy { prisonVisitsCreateContactEventQueue.dlqUrl }
+  internal val domainEventsSqsClient by lazy { prisonVisitsBookerEventsQueue.sqsClient }
+  internal val domainEventsSqsDlqClient by lazy { prisonVisitsBookerEventsQueue.sqsDlqClient }
+  internal val domainEventsQueueUrl by lazy { prisonVisitsBookerEventsQueue.queueUrl }
+  internal val domainEventsDlqUrl by lazy { prisonVisitsBookerEventsQueue.dlqUrl }
 
   internal val awsSnsClient by lazy { topic.snsClient }
   internal val topicArn by lazy { topic.arn }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -36,6 +36,13 @@ hmpps:
         subscribeTopicId: domainevents
         dlqMaxReceiveCount: 1
         visibilityTimeout: 1
+
+      prisonvisitsbookerevents:
+        queueName: ${random.uuid}
+        dlqName: ${random.uuid}
+        subscribeTopicId: domainevents
+        dlqMaxReceiveCount: 1
+        visibilityTimeout: 1
     topics:
       domainevents:
         arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}


### PR DESCRIPTION
## What does this PR do?
Alongside the prisoner contact created event, we now listen for the updated event to also try and auto approve any open visitor requests.

Also moves over to the new booker-events queue, which contains the 2 events. Old queue will be retired once this has been deployed to prod.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-6616