### PR TITLE
VB-6616 - Remove incorrect domain event processing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/enums/DomainEventTypes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/enums/DomainEventTypes.kt
@@ -2,5 +2,4 @@ package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums
 
 enum class DomainEventTypes(val value: String) {
   PRISONER_CONTACT_CREATED_EVENT("contacts-api.prisoner-contact.created"),
-  PRISONER_CONTACT_UPDATED_EVENT("contacts-api.prisoner-contact.updated"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/DomainEventListenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/DomainEventListenerService.kt
@@ -5,19 +5,19 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.DomainEventTypes
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.DomainEvent
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.handlers.PrisonerContactCreatedUpdatedEventHandler
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.handlers.PrisonerContactCreatedEventHandler
 
 @Service
-class DomainEventListenerService(val prisonerContactCreatedUpdatedEventHandler: PrisonerContactCreatedUpdatedEventHandler) {
+class DomainEventListenerService(val prisonerContactCreatedEventHandler: PrisonerContactCreatedEventHandler) {
   companion object {
     private val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
   fun handleMessage(domainEvent: DomainEvent) {
     when (domainEvent.eventType) {
-      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value, DomainEventTypes.PRISONER_CONTACT_UPDATED_EVENT.value -> {
-        LOG.info("Received create / update prisoner contact domain event - {}", domainEvent)
-        prisonerContactCreatedUpdatedEventHandler.handle(domainEvent)
+      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value -> {
+        LOG.info("Received create prisoner contact domain event - {}", domainEvent)
+        prisonerContactCreatedEventHandler.handle(domainEvent)
       }
       else -> {
         LOG.warn("Received unknown domain event - {}", domainEvent)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedEventHandler.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.additionalinfo.PrisonerContactCreatedAdditionalInfo
 
 @Service
-class PrisonerContactCreatedUpdatedEventHandler(
+class PrisonerContactCreatedEventHandler(
   @param:Qualifier("objectMapper")
   private val objectMapper: ObjectMapper,
   private val prisonerContactRegistryClient: PrisonerContactRegistryClient,
@@ -31,16 +31,16 @@ class PrisonerContactCreatedUpdatedEventHandler(
     val contactId = domainEvent.personReference.identifiers.firstOrNull { it.type == Identifier.DPS_CONTACT_ID }?.value
     val relationshipId = objectMapper.readValue(domainEvent.additionalInformation, PrisonerContactCreatedAdditionalInfo::class.java).prisonerContactId
 
-    LOG.info("PrisonerContactCreatedUpdatedEventHandler called for event ${domainEvent.eventType}, prisoner $prisonerId, contact $contactId and relationship (prisonerContactId) $relationshipId")
+    LOG.info("PrisonerContactCreatedEventHandler called for event ${domainEvent.eventType}, prisoner $prisonerId, contact $contactId and relationship (prisonerContactId) $relationshipId")
 
     if (prisonerId == null || contactId == null) {
-      LOG.error("PrisonerContactCreatedUpdatedEventHandler called for event ${domainEvent.eventType} with no prisonerId ($prisonerId) or contactId ($contactId), skipping processing of event")
+      LOG.error("PrisonerContactCreatedEventHandler called for event ${domainEvent.eventType} with no prisonerId ($prisonerId) or contactId ($contactId), skipping processing of event")
       return
     }
 
     val requests = visitorRequestsService.getActiveVisitorRequestsByPrisonerId(prisonerId)
     if (requests.isEmpty()) {
-      LOG.info("PrisonerContactCreatedUpdatedEventHandler - No visitor requests found for prisoner $prisonerId")
+      LOG.info("PrisonerContactCreatedEventHandler - No visitor requests found for prisoner $prisonerId")
       return
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedTest.kt
@@ -6,8 +6,7 @@ import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -20,18 +19,9 @@ import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.time.LocalDate
 
 @DisplayName("Test for Domain Event Prisoner Contact Created")
-class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase() {
-  companion object {
-    @JvmStatic
-    fun events(): List<String> = listOf(
-      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
-      DomainEventTypes.PRISONER_CONTACT_UPDATED_EVENT.value,
-    )
-  }
-
-  @ParameterizedTest(name = "when domain event ''{0}'' is found, then it is processed")
-  @MethodSource("events")
-  fun `when domain event is found, then it is processed`(event: String) {
+class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
+  @Test
+  fun `when domain event 'prisoner contact created' is found, then it is processed`() {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -39,8 +29,8 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     val contact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
 
     val domainEvent = createDomainEventJson(
-      event,
-      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )
@@ -65,16 +55,15 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.AUTO_APPROVED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
   }
 
-  @ParameterizedTest(name = "when domain event ''{0}'' is found but no visitor requests exist, then it is skipped")
-  @MethodSource("events")
-  fun `when domain event is found but no visitor requests exist, then it is skipped`(event: String) {
+  @Test
+  fun `when domain event 'prisoner contact created' is found but no visitor requests exist, then it is skipped`() {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -82,8 +71,8 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     val contact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
 
     val domainEvent = createDomainEventJson(
-      event,
-      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )
@@ -98,15 +87,14 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     verify(prisonerContactRegistryClientSpy, times(0)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
   }
 
-  @ParameterizedTest(name = "when domain event ''{0}'' is found but contact is not Social, then it is skipped")
-  @MethodSource("events")
-  fun `when domain event is found but contact is not Social, then it is skipped`(event: String) {
+  @Test
+  fun `when domain event 'prisoner contact created' is found but contact is not Social, then it is skipped`() {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -114,8 +102,8 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     val contact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "O")
 
     val domainEvent = createDomainEventJson(
-      event,
-      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )
@@ -140,16 +128,15 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
   }
 
-  @ParameterizedTest(name = "when domain event ''{0}'' is found but no requests are in status REQUESTED, then it is skipped")
-  @MethodSource("events")
-  fun `when domain event is found but no requests are in status REQUESTED, then it is skipped`(event: String) {
+  @Test
+  fun `when domain event 'prisoner contact created' is found but no requests are in status REQUESTED, then it is skipped`() {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
@@ -157,8 +144,8 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     val contact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
 
     val domainEvent = createDomainEventJson(
-      event,
-      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )
@@ -183,24 +170,23 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REJECTED)
     verify(prisonerContactRegistryClientSpy, times(0)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
   }
 
-  @ParameterizedTest(name = "when domain event ''{0}'' is found but relationship is not found on prisoner-contact-registry, then it is skipped")
-  @MethodSource("events")
-  fun `when domain event is found but relationship is not found on prisoner-contact-registry, then it is skipped`(event: String) {
+  @Test
+  fun `when domain event 'prisoner contact created' is found but relationship is not found on prisoner-contact-registry, then it is skipped`() {
     // Given
     val prisonerId = "AA123456"
     val contactId = "123456"
     val relationshipId = 9876L
 
     val domainEvent = createDomainEventJson(
-      event,
-      createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
       prisonerId,
       contactId,
     )
@@ -225,7 +211,7 @@ class DomainEventsPrisonerContactCreatedUpdatedTest : EventsIntegrationTestBase(
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(prisonerContactCreatedUpdatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.DomainEv
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.DomainEventListener
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.DomainEventListener.Companion.PRISON_VISITS_BOOKER_EVENTS_QUEUE_CONFIG_KEY
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.additionalinfo.PrisonerContactCreatedAdditionalInfo
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.handlers.PrisonerContactCreatedUpdatedEventHandler
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.listener.events.handlers.PrisonerContactCreatedEventHandler
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
@@ -95,7 +95,7 @@ abstract class EventsIntegrationTestBase {
   protected lateinit var domainEventListenerServiceSpy: DomainEventListenerService
 
   @MockitoSpyBean
-  protected lateinit var prisonerContactCreatedUpdatedEventHandlerSpy: PrisonerContactCreatedUpdatedEventHandler
+  protected lateinit var prisonerContactCreatedEventHandlerSpy: PrisonerContactCreatedEventHandler
 
   @MockitoSpyBean
   protected lateinit var visitorRequestsRepositorySpy: VisitorRequestsRepository
@@ -161,7 +161,7 @@ abstract class EventsIntegrationTestBase {
   }
     """.trimIndent().replace("\n", "").replace("  ", "")
 
-  fun createPrisonerContactCreatedUpdatedEventAdditionalInformationJson(prisonerContactId: Long): String = TestObjectMapper.mapper
+  fun createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId: Long): String = TestObjectMapper.mapper
     .writeValueAsString(PrisonerContactCreatedAdditionalInfo(prisonerContactId = prisonerContactId))
 
   fun createBooker(oneLoginSub: String, emailAddress: String): Booker {


### PR DESCRIPTION
The prisoner-contact-updated event seems to only relate to the relationship itself, not the contact details.

We need the contact-updated event. Removing this one and will add the correct one in the next PR.