### PR TITLE
Add new auto approved telemetry event if visitor request is auto approved

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerAuditService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.Booker
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.UPDATE_BOOKER_EMAIL
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.VISITOR_ADDED_TO_PRISONER
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.VISITOR_REQUEST_APPROVED_FOR_PRISONER
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.VISITOR_REQUEST_AUTO_APPROVED_FOR_PRISONER
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.VISITOR_REQUEST_REJECTED_FOR_PRISONER
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.RegisterPrisonerValidationError
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestRejectionReason
@@ -123,9 +124,13 @@ class BookerAuditService(
     sendTelemetryClientEvent(auditType, properties)
   }
 
-  fun auditLinkVisitorApproved(bookerReference: String, prisonNumber: String, visitorId: Long, requestReference: String) {
-    val auditType = VISITOR_REQUEST_APPROVED_FOR_PRISONER
-    val text = "Visitor ID - $visitorId approved for prisoner - $prisonNumber, request reference - $requestReference"
+  fun auditLinkVisitorApproved(bookerReference: String, prisonNumber: String, visitorId: Long, requestReference: String, autoApproval: Boolean) {
+    val auditType = if (autoApproval) {
+      VISITOR_REQUEST_AUTO_APPROVED_FOR_PRISONER
+    } else {
+      VISITOR_REQUEST_APPROVED_FOR_PRISONER
+    }
+    val text = "Visitor ID - $visitorId approved (autoApproved = $autoApproval) for prisoner - $prisonNumber, request reference - $requestReference"
     auditBookerEvent(bookerReference, auditType, text)
 
     // send event to telemetry client

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsService.kt
@@ -86,9 +86,9 @@ class VisitorRequestsService(
       REQUESTED -> {
         val booker = bookerDetailsService.getBookerByReference(bookerReference)
 
-        visitorRequestsStoreService.approveAndLinkVisitor(bookerReference, prisonerId = visitorRequest.prisonerId, visitorId = approveVisitorRequest.visitorId, requestReference = requestReference, autoApproval)
+        visitorRequestsStoreService.approveAndLinkVisitor(bookerReference, prisonerId = visitorRequest.prisonerId, visitorId = approveVisitorRequest.visitorId, requestReference = requestReference, autoApproval = autoApproval)
         // audit the event
-        bookerAuditService.auditLinkVisitorApproved(bookerReference = visitorRequest.bookerReference, prisonNumber = visitorRequest.prisonerId, visitorId = approveVisitorRequest.visitorId, requestReference = requestReference, autoApproval)
+        bookerAuditService.auditLinkVisitorApproved(bookerReference = visitorRequest.bookerReference, prisonNumber = visitorRequest.prisonerId, visitorId = approveVisitorRequest.visitorId, requestReference = requestReference, autoApproval = autoApproval)
         // send SNS event
         snsService.sendBookerPrisonerVisitorApprovedEvent(bookerReference = visitorRequest.bookerReference, prisonerId = visitorRequest.prisonerId, visitorId = approveVisitorRequest.visitorId.toString())
         LOG.info("Visitor request with reference $requestReference approved successfully")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsService.kt
@@ -88,7 +88,7 @@ class VisitorRequestsService(
 
         visitorRequestsStoreService.approveAndLinkVisitor(bookerReference, prisonerId = visitorRequest.prisonerId, visitorId = approveVisitorRequest.visitorId, requestReference = requestReference, autoApproval)
         // audit the event
-        bookerAuditService.auditLinkVisitorApproved(bookerReference = visitorRequest.bookerReference, prisonNumber = visitorRequest.prisonerId, visitorId = approveVisitorRequest.visitorId, requestReference = requestReference)
+        bookerAuditService.auditLinkVisitorApproved(bookerReference = visitorRequest.bookerReference, prisonNumber = visitorRequest.prisonerId, visitorId = approveVisitorRequest.visitorId, requestReference = requestReference, autoApproval)
         // send SNS event
         snsService.sendBookerPrisonerVisitorApprovedEvent(bookerReference = visitorRequest.bookerReference, prisonerId = visitorRequest.prisonerId, visitorId = approveVisitorRequest.visitorId.toString())
         LOG.info("Visitor request with reference $requestReference approved successfully")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/ApproveVisitorRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/ApproveVisitorRequestTest.kt
@@ -111,7 +111,7 @@ class ApproveVisitorRequestTest : IntegrationTestBase() {
 
     val auditEvents = bookerAuditRepository.findAll()
     assertThat(auditEvents).hasSize(1)
-    assertAuditEvent(auditEvents[0], bookerReference, VISITOR_REQUEST_APPROVED_FOR_PRISONER, "Visitor ID - $visitorIdToBeLinked approved for prisoner - $prisonerId, request reference - $requestReference")
+    assertAuditEvent(auditEvents[0], bookerReference, VISITOR_REQUEST_APPROVED_FOR_PRISONER, "Visitor ID - $visitorIdToBeLinked approved (autoApproved = false) for prisoner - $prisonerId, request reference - $requestReference")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.AddVisitorToBookerPrisonerRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.contact.registry.PrisonerContactDto
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.DomainEventTypes
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
@@ -26,7 +27,7 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     val prisonerId = "AA123456"
     val contactId = "123456"
     val relationshipId = 9876L
-    val contact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
+    val contact = PrisonerContactDto(personId = contactId.toLong(), firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
 
     val domainEvent = createDomainEventJson(
       DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
@@ -60,6 +61,17 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.AUTO_APPROVED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+
+    verify(telemetryClientSpy, times(1)).trackEvent(
+      BookerAuditType.VISITOR_REQUEST_AUTO_APPROVED_FOR_PRISONER.telemetryEventName,
+      mapOf(
+        "requestReference" to visitorRequest.reference,
+        "bookerReference" to booker.reference,
+        "prisonerId" to prisoner.prisonerId,
+        "visitorId" to contactId,
+      ),
+      null,
+    )
   }
 
   @Test
@@ -91,6 +103,8 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     verify(prisonerContactRegistryClientSpy, times(0)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
   }
 
   @Test
@@ -133,6 +147,8 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
   }
 
   @Test
@@ -175,6 +191,8 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REJECTED)
     verify(prisonerContactRegistryClientSpy, times(0)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
   }
 
   @Test
@@ -216,5 +234,7 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration.events
 
+import com.microsoft.applicationinsights.TelemetryClient
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
@@ -120,6 +121,9 @@ abstract class EventsIntegrationTestBase {
 
   @MockitoSpyBean
   protected lateinit var prisonerContactRegistryClientSpy: PrisonerContactRegistryClient
+
+  @MockitoSpyBean
+  protected lateinit var telemetryClientSpy: TelemetryClient
 
   @BeforeEach
   fun cleanQueue() {


### PR DESCRIPTION
## What does this PR do?
This will raise an auto approved telemetry event if one of our event consumers auto approves a requested visit.

- prisoner-contact created
- contact updated