### PR TITLE
VB-6590 - Remove first name validation during automated approval checks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
@@ -44,7 +44,7 @@ class VisitorRequestsStoreService(
     visitorRequestsValidationService.validateVisitorRequest(booker, prisonerId, request, contactList)
 
     val matchingContact = contactList.firstOrNull { contact ->
-      visitorRequestsValidationService.matchContactNameAndDob(contact, request.firstName, request.lastName, request.dateOfBirth) && contact.personId != null
+      visitorRequestsValidationService.matchContactNameAndDob(contact, request.lastName, request.dateOfBirth) && contact.personId != null
     }
 
     val visitorRequestStatus = if (matchingContact != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
@@ -41,48 +41,36 @@ class VisitorRequestsValidationService(
 
   fun matchContactNameAndDob(
     contact: PrisonerContactDto,
-    firstName: String,
     lastName: String,
     dateOfBirth: LocalDate,
   ): Boolean = matchNameAndDob(
-    contact.firstName,
     contact.lastName,
     contact.dateOfBirth,
-    firstName,
     lastName,
     dateOfBirth,
   )
 
   fun matchContactNameAndDob(
     contact: ContactDto,
-    firstName: String,
     lastName: String,
     dateOfBirth: LocalDate,
   ): Boolean = matchNameAndDob(
-    contact.firstName,
     contact.lastName,
     contact.dateOfBirth,
-    firstName,
     lastName,
     dateOfBirth,
   )
 
   private fun matchNameAndDob(
-    contactFirstName: String,
     contactLastName: String,
     contactDateOfBirth: LocalDate? = null,
-    firstName: String,
     lastName: String,
     dateOfBirth: LocalDate,
   ): Boolean {
-    val contactFirst = stringInputUtils.sanitiseText(contactFirstName)
     val contactLast = stringInputUtils.sanitiseText(contactLastName)
-    val inputFirst = stringInputUtils.sanitiseText(firstName)
     val inputLast = stringInputUtils.sanitiseText(lastName)
 
-    return contactFirst.equals(inputFirst, ignoreCase = true) &&
-      contactLast.equals(inputLast, ignoreCase = true) &&
-      contactDateOfBirth == dateOfBirth
+    return contactLast.equals(inputLast, ignoreCase = true) && contactDateOfBirth == dateOfBirth
   }
 
   private fun validateBookerPrisonerRelationship(booker: Booker, prisonerId: String) {
@@ -120,7 +108,7 @@ class VisitorRequestsValidationService(
 
   private fun validateVisitorAlreadyAdded(booker: Booker, prisonerId: String, visitorRequest: AddVisitorToBookerPrisonerRequestDto, prisonerContactList: List<PrisonerContactDto>) {
     prisonerContactList.forEach { contact ->
-      if (matchContactNameAndDob(contact, visitorRequest.firstName, visitorRequest.lastName, visitorRequest.dateOfBirth)
+      if (matchContactNameAndDob(contact, visitorRequest.lastName, visitorRequest.dateOfBirth)
       ) {
         if (booker.permittedPrisoners.first { it.prisonerId == prisonerId }.permittedVisitors.any { it.visitorId == contact.personId }) {
           throw VisitorRequestValidationException(VisitorRequestValidationError.VISITOR_ALREADY_EXISTS)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/ContactUpdatedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/ContactUpdatedEventHandler.kt
@@ -51,7 +51,6 @@ class ContactUpdatedEventHandler(
       for (request in requests) {
         val matches = visitorRequestsValidationService.matchContactNameAndDob(
           contactDetails,
-          request.firstName,
           request.lastName,
           request.dateOfBirth,
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedEventHandler.kt
@@ -59,7 +59,7 @@ class PrisonerContactCreatedEventHandler(
     }
 
     requests.forEach { request ->
-      if (visitorRequestsValidationService.matchContactNameAndDob(contactDetails, request.firstName, request.lastName, request.dateOfBirth)) {
+      if (visitorRequestsValidationService.matchContactNameAndDob(contactDetails, request.lastName, request.dateOfBirth)) {
         LOG.info("PrisonerContactCreatedEventHandler - Approving visitor request for prisoner $prisonerId, contactId: $contactId, relationshipId: $relationshipId, visitor request reference: ${request.reference}")
         visitorRequestsService.approveAndLinkVisitorRequest(request.reference, ApproveVisitorRequestDto(contactDetails.personId!!, SYSTEM_USER_NAME), autoApproval = true)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/SubmitVisitorRequestAddVisitorToBookerPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/SubmitVisitorRequestAddVisitorToBookerPrisonerTest.kt
@@ -118,6 +118,49 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
   }
 
   @Test
+  fun `when visitor request comes in and is eligible for automatic approval (lastname and DOB match), it is saved to database successfully with status auto_approved`() {
+    // Given
+    val booker = createBooker(oneLoginSub = "123", emailAddress = "test@test.come")
+    val prisoner = createPrisoner(booker, "AA123456")
+    val visitorRequestDto = AddVisitorToBookerPrisonerRequestDto(
+      firstName = "Jon",
+      lastName = "Smith",
+      dateOfBirth = LocalDate.now().minusYears(21),
+    )
+
+    // When
+    val prisonerContact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact))
+    val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+
+    val visitorRequests = visitorRequestsRepository.findAll()
+    assertThat(visitorRequests).hasSize(1)
+    assertVisitorRequest(visitorRequests[0], booker.reference, prisoner.prisonerId, visitorRequestDto, VisitorRequestsStatus.AUTO_APPROVED, personId = prisonerContact.personId)
+    val visitRequest = visitorRequests[0]
+
+    verify(telemetryClientSpy, times(1)).trackEvent(
+      BookerAuditType.VISITOR_REQUEST_SUBMITTED.telemetryEventName,
+      mapOf(
+        "bookerReference" to booker.reference,
+        "prisonerId" to prisoner.prisonerId,
+        "requestReference" to visitRequest.reference,
+        "visitorRequestStatus" to visitRequest.status.name,
+        "prisonId" to prisoner.prisonCode,
+        "visitorId" to prisonerContact.personId.toString(),
+      ),
+      null,
+    )
+    val auditEvents = bookerAuditRepository.findAll()
+    assertThat(auditEvents).hasSize(2)
+    assertAuditEvent(auditEvents[0], booker.reference, BookerAuditType.VISITOR_REQUEST_SUBMITTED, "Booker ${booker.reference}, submitted request to add visitor to prisoner ${prisoner.prisonerId}, request reference - ${visitRequest.reference}")
+    assertAuditEvent(auditEvents[1], booker.reference, BookerAuditType.VISITOR_REQUEST_AUTO_APPROVED_FOR_PRISONER, "Visitor ID - ${visitRequest.visitorId} auto approved for prisoner - ${prisoner.prisonerId}, request reference - ${visitRequest.reference}")
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId = prisoner.prisonerId)
+  }
+
+  @Test
   fun `when visitor request comes in and the only matching contact is an unapproved visitor then request is still matched and saved to database with status auto_approved`() {
     // Given
     val booker = createBooker(oneLoginSub = "123", emailAddress = "test@test.come")


### PR DESCRIPTION
## What does this PR do?
In the matcher validation method, remove the need for first name to match the contact for automatic approval.