### PR TITLE
VB-6590 - Update visitor requests validation and auto approval logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
@@ -44,11 +44,13 @@ class VisitorRequestsStoreService(
     visitorRequestsValidationService.validateVisitorRequest(booker, prisonerId, request, contactList)
 
     val matchingContact = contactList.firstOrNull { contact ->
-      visitorRequestsValidationService.matchContactNameAndDob(contact, request.firstName, request.lastName, request.dateOfBirth) && contact.personId != null
+      visitorRequestsValidationService.matchContactLastNameAndDob(contact, request.lastName, request.dateOfBirth) && contact.personId != null
     }
 
-    val visitorRequestStatus = if (matchingContact != null) {
-      // Only create a visitor entry if we find a 100% match (Auto approval path)
+    val multipleMatches = visitorRequestsValidationService.hasMultipleMatchingContacts(contactList, request.lastName, request.dateOfBirth)
+
+    // If we have a matching contact and there is only 1 of them, begin auto approval process.
+    val visitorRequestStatus = if (matchingContact != null && !multipleMatches) {
       val bookerPrisonerEntity = booker.permittedPrisoners.first { it.prisonerId == prisonerId }
 
       visitorRepository.saveAndFlush(
@@ -72,7 +74,7 @@ class VisitorRequestsStoreService(
         lastName = request.lastName.trim(),
         dateOfBirth = request.dateOfBirth,
         status = visitorRequestStatus, // REQUESTED or AUTO_APPROVED
-        visitorId = matchingContact?.personId,
+        visitorId = if (!multipleMatches) matchingContact?.personId else null,
       ),
     )
 
@@ -85,7 +87,7 @@ class VisitorRequestsStoreService(
       bookerReference = bookerReference,
       prisonerId = prisonerId,
       prisonId = prisonerRegisteredPrisonCode,
-      visitorId = matchingContact?.personId,
+      visitorId = if (!multipleMatches) matchingContact?.personId else null,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
@@ -48,7 +48,11 @@ class VisitorRequestsValidationService(
     contacts: List<PrisonerContactDto>,
     lastName: String,
     dateOfBirth: LocalDate?,
-  ): Boolean = contacts.count { contact -> matchContactLastNameAndDob(contact, lastName, dateOfBirth) } > 1
+  ): Boolean = contacts.count { contact ->
+    isEligibleMatchingContact(contact) && matchContactLastNameAndDob(contact, lastName, dateOfBirth)
+  } > 1
+
+  private fun isEligibleMatchingContact(contact: PrisonerContactDto): Boolean = contact.personId != null
 
   fun matchContactLastNameAndDob(
     contact: PrisonerContactDto,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
@@ -25,7 +25,12 @@ class VisitorRequestsValidationService(
     private val LOG = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun validateVisitorRequest(booker: Booker, prisonerId: String, visitorRequest: AddVisitorToBookerPrisonerRequestDto, prisonerContactList: List<PrisonerContactDto>) {
+  fun validateVisitorRequest(
+    booker: Booker,
+    prisonerId: String,
+    visitorRequest: AddVisitorToBookerPrisonerRequestDto,
+    prisonerContactList: List<PrisonerContactDto>,
+  ) {
     LOG.info("Entered VisitorRequestsService - validateVisitorRequest - For booker ${booker.reference}, prisoner $prisonerId")
 
     validateBookerPrisonerRelationship(booker, prisonerId)
@@ -39,49 +44,44 @@ class VisitorRequestsValidationService(
     LOG.info("Successfully validated visitor request - For booker ${booker.reference}, prisoner $prisonerId")
   }
 
-  fun matchContactNameAndDob(
+  fun hasMultipleMatchingContacts(
+    contacts: List<PrisonerContactDto>,
+    lastName: String,
+    dateOfBirth: LocalDate?,
+  ): Boolean = contacts.count { contact -> matchContactLastNameAndDob(contact, lastName, dateOfBirth) } > 1
+
+  fun matchContactLastNameAndDob(
     contact: PrisonerContactDto,
-    firstName: String,
     lastName: String,
-    dateOfBirth: LocalDate,
-  ): Boolean = matchNameAndDob(
-    contact.firstName,
+    dateOfBirth: LocalDate?,
+  ): Boolean = matchLastNameAndDob(
     contact.lastName,
     contact.dateOfBirth,
-    firstName,
     lastName,
     dateOfBirth,
   )
 
-  fun matchContactNameAndDob(
+  fun matchContactLastNameAndDob(
     contact: ContactDto,
-    firstName: String,
     lastName: String,
-    dateOfBirth: LocalDate,
-  ): Boolean = matchNameAndDob(
-    contact.firstName,
+    dateOfBirth: LocalDate?,
+  ): Boolean = matchLastNameAndDob(
     contact.lastName,
     contact.dateOfBirth,
-    firstName,
     lastName,
     dateOfBirth,
   )
 
-  private fun matchNameAndDob(
-    contactFirstName: String,
+  private fun matchLastNameAndDob(
     contactLastName: String,
     contactDateOfBirth: LocalDate? = null,
-    firstName: String,
     lastName: String,
-    dateOfBirth: LocalDate,
+    dateOfBirth: LocalDate?,
   ): Boolean {
-    val contactFirst = stringInputUtils.sanitiseText(contactFirstName)
     val contactLast = stringInputUtils.sanitiseText(contactLastName)
-    val inputFirst = stringInputUtils.sanitiseText(firstName)
     val inputLast = stringInputUtils.sanitiseText(lastName)
 
-    return contactFirst.equals(inputFirst, ignoreCase = true) &&
-      contactLast.equals(inputLast, ignoreCase = true) &&
+    return contactLast.equals(inputLast, ignoreCase = true) &&
       contactDateOfBirth == dateOfBirth
   }
 
@@ -119,13 +119,24 @@ class VisitorRequestsValidationService(
   }
 
   private fun validateVisitorAlreadyAdded(booker: Booker, prisonerId: String, visitorRequest: AddVisitorToBookerPrisonerRequestDto, prisonerContactList: List<PrisonerContactDto>) {
-    prisonerContactList.forEach { contact ->
-      if (matchContactNameAndDob(contact, visitorRequest.firstName, visitorRequest.lastName, visitorRequest.dateOfBirth)
-      ) {
-        if (booker.permittedPrisoners.first { it.prisonerId == prisonerId }.permittedVisitors.any { it.visitorId == contact.personId }) {
-          throw VisitorRequestValidationException(VisitorRequestValidationError.VISITOR_ALREADY_EXISTS)
-        }
-      }
+    val permittedVisitorIds = booker.permittedPrisoners
+      .first { it.prisonerId == prisonerId }
+      .permittedVisitors
+      .map { it.visitorId }
+      .distinct()
+      .toList()
+
+    val visitorAlreadyExists = prisonerContactList.any { contact ->
+      matchContactLastNameAndDob(
+        contact,
+        visitorRequest.lastName,
+        visitorRequest.dateOfBirth,
+      ) &&
+        contact.personId in permittedVisitorIds
+    }
+
+    if (visitorAlreadyExists) {
+      throw VisitorRequestValidationException(VisitorRequestValidationError.VISITOR_ALREADY_EXISTS)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
@@ -131,11 +131,12 @@ class VisitorRequestsValidationService(
       .toList()
 
     val visitorAlreadyExists = prisonerContactList.any { contact ->
-      contact.personId in permittedVisitorIds && matchContactLastNameAndDob(
-        contact,
-        visitorRequest.lastName,
-        visitorRequest.dateOfBirth,
-      )
+      contact.personId in permittedVisitorIds &&
+        matchContactLastNameAndDob(
+          contact,
+          visitorRequest.lastName,
+          visitorRequest.dateOfBirth,
+        )
     }
 
     if (visitorAlreadyExists) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
@@ -131,12 +131,11 @@ class VisitorRequestsValidationService(
       .toList()
 
     val visitorAlreadyExists = prisonerContactList.any { contact ->
-      matchContactLastNameAndDob(
+      contact.personId in permittedVisitorIds && matchContactLastNameAndDob(
         contact,
         visitorRequest.lastName,
         visitorRequest.dateOfBirth,
-      ) &&
-        contact.personId in permittedVisitorIds
+      )
     }
 
     if (visitorAlreadyExists) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/ContactUpdatedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/ContactUpdatedEventHandler.kt
@@ -48,10 +48,17 @@ class ContactUpdatedEventHandler(
         continue
       }
 
+      val prisonerSocialContactList = prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerNumber)
+
+      val multipleMatches = visitorRequestsValidationService.hasMultipleMatchingContacts(prisonerSocialContactList, contactDetails.lastName, contactDetails.dateOfBirth)
+      if (multipleMatches) {
+        LOG.info("Skipping processing of event as multiple contacts exist with same last name and DOB - cannot auto approve {}", prisonerNumber)
+        return
+      }
+
       for (request in requests) {
-        val matches = visitorRequestsValidationService.matchContactNameAndDob(
+        val matches = visitorRequestsValidationService.matchContactLastNameAndDob(
           contactDetails,
-          request.firstName,
           request.lastName,
           request.dateOfBirth,
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/ContactUpdatedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/ContactUpdatedEventHandler.kt
@@ -53,7 +53,7 @@ class ContactUpdatedEventHandler(
       val multipleMatches = visitorRequestsValidationService.hasMultipleMatchingContacts(prisonerSocialContactList, contactDetails.lastName, contactDetails.dateOfBirth)
       if (multipleMatches) {
         LOG.info("Skipping processing of event as multiple contacts exist with same last name and DOB - cannot auto approve {}", prisonerNumber)
-        return
+        continue
       }
 
       for (request in requests) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedEventHandler.kt
@@ -58,8 +58,16 @@ class PrisonerContactCreatedEventHandler(
       return
     }
 
+    val prisonerSocialContactList = prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerId)
+
+    val multipleMatches = visitorRequestsValidationService.hasMultipleMatchingContacts(prisonerSocialContactList, contactDetails.lastName, contactDetails.dateOfBirth)
+    if (multipleMatches) {
+      LOG.info("Skipping processing of event as multiple contacts exist with same last name and DOB - cannot auto approve $prisonerId: $prisonerId, contactId: $contactId")
+      return
+    }
+
     requests.forEach { request ->
-      if (visitorRequestsValidationService.matchContactNameAndDob(contactDetails, request.firstName, request.lastName, request.dateOfBirth)) {
+      if (visitorRequestsValidationService.matchContactLastNameAndDob(contactDetails, request.lastName, request.dateOfBirth)) {
         LOG.info("PrisonerContactCreatedEventHandler - Approving visitor request for prisoner $prisonerId, contactId: $contactId, relationshipId: $relationshipId, visitor request reference: ${request.reference}")
         visitorRequestsService.approveAndLinkVisitorRequest(request.reference, ApproveVisitorRequestDto(contactDetails.personId!!, SYSTEM_USER_NAME), autoApproval = true)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/listener/events/handlers/PrisonerContactCreatedEventHandler.kt
@@ -62,7 +62,7 @@ class PrisonerContactCreatedEventHandler(
 
     val multipleMatches = visitorRequestsValidationService.hasMultipleMatchingContacts(prisonerSocialContactList, contactDetails.lastName, contactDetails.dateOfBirth)
     if (multipleMatches) {
-      LOG.info("Skipping processing of event as multiple contacts exist with same last name and DOB - cannot auto approve $prisonerId: $prisonerId, contactId: $contactId")
+      LOG.info("Skipping processing of event as multiple contacts exist with same last name and DOB - cannot auto approve prisonerId: $prisonerId, contactId: $contactId")
       return
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/SubmitVisitorRequestAddVisitorToBookerPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/SubmitVisitorRequestAddVisitorToBookerPrisonerTest.kt
@@ -45,7 +45,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
 
     // When
     val prisonerContact = PrisonerContactDto(personId = 543L, firstName = "Random", lastName = "Contact", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact))
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact))
     val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
 
     // Then
@@ -87,7 +87,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
 
     // When
     val prisonerContact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact))
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact))
     val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
 
     // Then
@@ -131,7 +131,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
     // When
     // match exists but is unapproved
     val prisonerContactUnapproved = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = false, contactType = "S")
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContactUnapproved))
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContactUnapproved))
     val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
 
     // Then
@@ -162,52 +162,6 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
   }
 
   @Test
-  fun `when visitor request added and there is 1 matching approved and 1 matching unapproved visitor with same details match is made with approved visitor`() {
-    // Given
-    val booker = createBooker(oneLoginSub = "123", emailAddress = "test@test.come")
-    val prisoner = createPrisoner(booker, "AA123456")
-    val visitorRequestDto = AddVisitorToBookerPrisonerRequestDto(
-      firstName = "John",
-      lastName = "Smith",
-      dateOfBirth = LocalDate.now().minusYears(21),
-    )
-
-    // When
-    // matching details but unapproved and first on list
-    val prisonerContactUnapproved = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = false, contactType = "S")
-    // matching details but approved and last on list
-    val prisonerContactApproved = PrisonerContactDto(personId = 544L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContactUnapproved, prisonerContactApproved))
-    val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
-
-    // Then
-    responseSpec.expectStatus().isCreated
-
-    val visitorRequests = visitorRequestsRepository.findAll()
-    assertThat(visitorRequests).hasSize(1)
-    assertVisitorRequest(visitorRequests[0], booker.reference, prisoner.prisonerId, visitorRequestDto, VisitorRequestsStatus.AUTO_APPROVED, personId = prisonerContactApproved.personId)
-    val visitRequest = visitorRequests[0]
-
-    verify(telemetryClientSpy, times(1)).trackEvent(
-      BookerAuditType.VISITOR_REQUEST_SUBMITTED.telemetryEventName,
-      mapOf(
-        "bookerReference" to booker.reference,
-        "prisonerId" to prisoner.prisonerId,
-        "requestReference" to visitRequest.reference,
-        "visitorRequestStatus" to visitRequest.status.name,
-        "prisonId" to prisoner.prisonCode,
-        "visitorId" to prisonerContactApproved.personId.toString(),
-      ),
-      null,
-    )
-    val auditEvents = bookerAuditRepository.findAll()
-    assertThat(auditEvents).hasSize(2)
-    assertAuditEvent(auditEvents[0], booker.reference, BookerAuditType.VISITOR_REQUEST_SUBMITTED, "Booker ${booker.reference}, submitted request to add visitor to prisoner ${prisoner.prisonerId}, request reference - ${visitRequest.reference}")
-    assertAuditEvent(auditEvents[1], booker.reference, BookerAuditType.VISITOR_REQUEST_AUTO_APPROVED_FOR_PRISONER, "Visitor ID - ${visitRequest.visitorId} auto approved for prisoner - ${prisoner.prisonerId}, request reference - ${visitRequest.reference}")
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId = prisoner.prisonerId)
-  }
-
-  @Test
   fun `when visitor request comes in, 100 percent match checking ignores special chars, it is saved to database successfully with status auto_approved`() {
     // Given
     val booker = createBooker(oneLoginSub = "123", emailAddress = "test@test.come")
@@ -220,7 +174,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
 
     // When
     val prisonerContact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = false, contactType = "S")
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact))
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact))
     val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
 
     // Then
@@ -263,7 +217,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
 
     // When
     val prisonerContact = PrisonerContactDto(personId = 543L, firstName = "jOhN", lastName = "sMiTh", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact))
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact))
     val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
 
     // Then
@@ -318,6 +272,50 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
     val visitorRequests = visitorRequestsRepository.findAll()
     assertThat(visitorRequests).hasSize(0)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId)
+  }
+
+  @Test
+  fun `when visitor request comes in and multiple contacts have a 100 percent match, it is saved to database successfully with status requested`() {
+    // Given
+    val booker = createBooker(oneLoginSub = "123", emailAddress = "test@test.come")
+    val prisoner = createPrisoner(booker, "AA123456")
+    val visitorRequestDto = AddVisitorToBookerPrisonerRequestDto(
+      firstName = "John",
+      lastName = "Smith",
+      dateOfBirth = LocalDate.now().minusYears(21),
+    )
+
+    // When
+    val prisonerContact1 = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
+    val prisonerContact2 = PrisonerContactDto(personId = 544L, firstName = "James", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
+
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = prisoner.prisonerId, listOf(prisonerContact1, prisonerContact2))
+    val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+
+    val visitorRequests = visitorRequestsRepository.findAll()
+    assertThat(visitorRequests).hasSize(1)
+    assertVisitorRequest(visitorRequests[0], booker.reference, prisoner.prisonerId, visitorRequestDto, status = VisitorRequestsStatus.REQUESTED, personId = null)
+
+    val visitRequest = visitorRequests[0]
+
+    verify(telemetryClientSpy, times(1)).trackEvent(
+      BookerAuditType.VISITOR_REQUEST_SUBMITTED.telemetryEventName,
+      mapOf(
+        "bookerReference" to booker.reference,
+        "prisonerId" to prisoner.prisonerId,
+        "requestReference" to visitRequest.reference,
+        "visitorRequestStatus" to visitRequest.status.name,
+        "prisonId" to prisoner.prisonCode,
+      ),
+      null,
+    )
+    val auditEvents = bookerAuditRepository.findAll()
+    assertThat(auditEvents).hasSize(1)
+    assertAuditEvent(auditEvents[0], booker.reference, BookerAuditType.VISITOR_REQUEST_SUBMITTED, "Booker ${booker.reference}, submitted request to add visitor to prisoner ${prisoner.prisonerId}, request reference - ${visitRequest.reference}")
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId = prisoner.prisonerId)
   }
 
   @Test
@@ -396,7 +394,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
     )
 
     // When
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, listOf(PrisonerContactDto(personId = visitor.visitorId, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")))
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = prisoner.prisonerId, listOf(PrisonerContactDto(personId = visitor.visitorId, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")))
     val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
 
     // Then
@@ -424,7 +422,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
     )
 
     // When
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = prisoner.prisonerId, null, HttpStatus.INTERNAL_SERVER_ERROR)
     val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
 
     // Then
@@ -450,7 +448,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
     )
 
     // When
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisoner.prisonerId, null, HttpStatus.NOT_FOUND)
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = prisoner.prisonerId, null, HttpStatus.NOT_FOUND)
     val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, prisoner.prisonerId, visitorRequestDto)
 
     // Then

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsContactUpdatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsContactUpdatedTest.kt
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.AddVisitorToBookerPrisonerRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.contact.registry.ContactDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.contact.registry.ContactLinkedSocialPrisonerDto
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.DomainEventTypes
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
@@ -40,8 +41,17 @@ class DomainEventsContactUpdatedTest : EventsIntegrationTestBase() {
       dateOfBirth = LocalDate.now().minusYears(21),
     )
 
+    val prisonerContact = PrisonerContactDto(
+      firstName = "john",
+      lastName = "smith",
+      dateOfBirth = LocalDate.now().minusYears(21),
+      approvedVisitor = true,
+      contactType = "S",
+    )
+
     prisonerContactRegistryMockServer.stubGetContact(contactId, contact)
     prisonerContactRegistryMockServer.stubGetContactLinkedSocialPrisoners(contactId, listOf(ContactLinkedSocialPrisonerDto(prisonerId)))
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId, listOf(prisonerContact))
 
     val booker = createBooker("oneSub", "testEmail@test.com")
     val prisoner = createPrisoner(booker, prisonerId)
@@ -68,6 +78,7 @@ class DomainEventsContactUpdatedTest : EventsIntegrationTestBase() {
 
     verify(prisonerContactRegistryClientSpy, times(1)).getContact(contactId)
     verify(prisonerContactRegistryClientSpy, times(1)).getContactLinkedSocialPrisoners(contactId)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId)
   }
 
   @Test
@@ -110,6 +121,7 @@ class DomainEventsContactUpdatedTest : EventsIntegrationTestBase() {
 
     verify(prisonerContactRegistryClientSpy, times(1)).getContact(contactId)
     verify(prisonerContactRegistryClientSpy, times(1)).getContactLinkedSocialPrisoners(contactId)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(prisonerId)
   }
 
   @Test
@@ -149,6 +161,7 @@ class DomainEventsContactUpdatedTest : EventsIntegrationTestBase() {
 
     verify(prisonerContactRegistryClientSpy, times(1)).getContact(contactId)
     verify(prisonerContactRegistryClientSpy, times(1)).getContactLinkedSocialPrisoners(contactId)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(prisonerId)
   }
 
   @Test
@@ -234,5 +247,72 @@ class DomainEventsContactUpdatedTest : EventsIntegrationTestBase() {
 
     verify(prisonerContactRegistryClientSpy, times(1)).getContact(contactId)
     verify(prisonerContactRegistryClientSpy, times(1)).getContactLinkedSocialPrisoners(contactId)
+  }
+
+  @Test
+  fun `when domain event 'contact updated' is found, but multiple contacts match, then it is skipped`() {
+    // Given
+    val contactId = "123456"
+    val prisonerId = "AA123456"
+
+    val domainEvent = createDomainEventJson(
+      DomainEventTypes.CONTACT_UPDATED_EVENT.value,
+      createContactUpdatedEventAdditionalInformationJson(contactId = contactId.toLong()),
+      contactId = contactId,
+    )
+
+    val contact = ContactDto(
+      contactId = contactId.toLong(),
+      firstName = "john",
+      lastName = "smith",
+      dateOfBirth = LocalDate.now().minusYears(21),
+    )
+
+    val prisonerContact1 = PrisonerContactDto(
+      firstName = "john",
+      lastName = "smith",
+      dateOfBirth = LocalDate.now().minusYears(21),
+      approvedVisitor = true,
+      contactType = "S",
+    )
+
+    val prisonerContact2 = PrisonerContactDto(
+      firstName = "james",
+      lastName = "smith",
+      dateOfBirth = LocalDate.now().minusYears(21),
+      approvedVisitor = true,
+      contactType = "S",
+    )
+
+    prisonerContactRegistryMockServer.stubGetContact(contactId, contact)
+    prisonerContactRegistryMockServer.stubGetContactLinkedSocialPrisoners(contactId, listOf(ContactLinkedSocialPrisonerDto(prisonerId)))
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId, listOf(prisonerContact1, prisonerContact2))
+
+    val booker = createBooker("oneSub", "testEmail@test.com")
+    val prisoner = createPrisoner(booker, prisonerId)
+
+    val visitorRequest = createVisitorRequest(
+      booker.reference,
+      prisoner.prisonerId,
+      AddVisitorToBookerPrisonerRequestDto("john", "smith", LocalDate.now().minusYears(21)),
+      status = VisitorRequestsStatus.REQUESTED,
+    )
+
+    val publishRequest = createDomainEventPublishRequest(domainEvent)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
+    await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
+    await untilAsserted { verify(contactUpdatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+
+    assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)
+
+    verify(prisonerContactRegistryClientSpy, times(1)).getContact(contactId)
+    verify(prisonerContactRegistryClientSpy, times(1)).getContactLinkedSocialPrisoners(contactId)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsContactUpdatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsContactUpdatedTest.kt
@@ -42,6 +42,7 @@ class DomainEventsContactUpdatedTest : EventsIntegrationTestBase() {
     )
 
     val prisonerContact = PrisonerContactDto(
+      personId = 123456L,
       firstName = "john",
       lastName = "smith",
       dateOfBirth = LocalDate.now().minusYears(21),
@@ -269,6 +270,7 @@ class DomainEventsContactUpdatedTest : EventsIntegrationTestBase() {
     )
 
     val prisonerContact1 = PrisonerContactDto(
+      personId = 123456L,
       firstName = "john",
       lastName = "smith",
       dateOfBirth = LocalDate.now().minusYears(21),
@@ -277,6 +279,7 @@ class DomainEventsContactUpdatedTest : EventsIntegrationTestBase() {
     )
 
     val prisonerContact2 = PrisonerContactDto(
+      personId = 98765L,
       firstName = "james",
       lastName = "smith",
       dateOfBirth = LocalDate.now().minusYears(21),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/DomainEventsPrisonerContactCreatedTest.kt
@@ -47,6 +47,7 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     )
 
     prisonerContactRegistryMockServer.stubGetPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId, contact)
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId, listOf(contact))
 
     val publishRequest = createDomainEventPublishRequest(domainEvent)
 
@@ -61,6 +62,7 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.AUTO_APPROVED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId)
 
     verify(telemetryClientSpy, times(1)).trackEvent(
       BookerAuditType.VISITOR_REQUEST_AUTO_APPROVED_FOR_PRISONER.telemetryEventName,
@@ -90,8 +92,6 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
       contactId,
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId, contact)
-
     val publishRequest = createDomainEventPublishRequest(domainEvent)
 
     // When
@@ -104,6 +104,7 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     verify(prisonerContactRegistryClientSpy, times(0)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(prisonerId)
 
     verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
   }
@@ -148,6 +149,7 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(prisonerId)
 
     verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
   }
@@ -192,6 +194,7 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REJECTED)
     verify(prisonerContactRegistryClientSpy, times(0)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(prisonerId)
 
     verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
   }
@@ -235,6 +238,54 @@ class DomainEventsPrisonerContactCreatedTest : EventsIntegrationTestBase() {
 
     assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)
     verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(prisonerId)
+
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
+  }
+
+  @Test
+  fun `when domain event 'prisoner contact created' is found, but multiple contacts match details provided then it is skipped`() {
+    // Given
+    val prisonerId = "AA123456"
+    val contactId = "123456"
+    val relationshipId = 9876L
+    val contact1 = PrisonerContactDto(personId = contactId.toLong(), firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
+    val contact2 = PrisonerContactDto(personId = 9876654L, firstName = "Jake", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
+
+    val domainEvent = createDomainEventJson(
+      DomainEventTypes.PRISONER_CONTACT_CREATED_EVENT.value,
+      createPrisonerContactCreatedEventAdditionalInformationJson(prisonerContactId = relationshipId),
+      prisonerId,
+      contactId,
+    )
+
+    val booker = createBooker("oneSub", "testEmail@test.com")
+    val prisoner = createPrisoner(booker, prisonerId)
+
+    val visitorRequest = createVisitorRequest(
+      booker.reference,
+      prisoner.prisonerId,
+      AddVisitorToBookerPrisonerRequestDto("john", "smith", LocalDate.now().minusYears(21)),
+      status = VisitorRequestsStatus.REQUESTED,
+    )
+
+    prisonerContactRegistryMockServer.stubGetPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId, contact1)
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId, listOf(contact1, contact2))
+
+    val publishRequest = createDomainEventPublishRequest(domainEvent)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
+    await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
+    await untilAsserted { verify(prisonerContactCreatedEventHandlerSpy, times(1)).handle(any()) }
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+
+    assertThat(visitorRequestsRepositorySpy.findVisitorRequestByReference(visitorRequest.reference)!!.status).isEqualTo(VisitorRequestsStatus.REQUESTED)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId)
 
     verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/mock/PrisonerContactRegistryMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/mock/PrisonerContactRegistryMockServer.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration.mock
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration.mock.MockUtils.Companion.getJsonString
 
 class PrisonerContactRegistryMockServer : WireMockServer(8093) {
-  fun stubGetPrisonerContacts(
+  fun stubGetPrisonerSocialContacts(
     prisonerId: String,
     contactsList: List<PrisonerContactDto>?,
     httpStatus: HttpStatus = HttpStatus.NOT_FOUND,


### PR DESCRIPTION
## What does this PR do?
Instead of requiring first name to match, we are removing it due to bad data in the system.

Also add a new check if there are multiple contacts who are eligible for the 100% auto approval match, then skip auto approving because we cannot for certain, approve the right one.

Add test coverage for this.