### PR TITLE
Remove first name from validation checks for prisoner registering

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/enums/RegisterPrisonerValidationError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/enums/RegisterPrisonerValidationError.kt
@@ -5,7 +5,6 @@ enum class RegisterPrisonerValidationError(val telemetryEventName: String) {
   BOOKER_ALREADY_HAS_A_PRISONER("booker-has-active-prisoner"),
   PRISONER_ALREADY_REGISTERED_AGAINST_BOOKER("prisoner-already-registered"),
   PRISONER_NOT_FOUND("prisoner-not-found"),
-  FIRST_NAME_INCORRECT("first-name-incorrect"),
   LAST_NAME_INCORRECT("last-name-incorrect"),
   DOB_INCORRECT("dob-incorrect"),
   PRISON_CODE_INCORRECT("prison-code-incorrect"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/utils/RegisterPrisonerValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/utils/RegisterPrisonerValidator.kt
@@ -34,9 +34,6 @@ class RegisterPrisonerValidator(private val stringInputUtils: StringInputUtils) 
     if (prisonerSearchPrisoner == null) {
       errors.add(RegisterPrisonerValidationError.PRISONER_NOT_FOUND)
     } else {
-      validateFirstName(registerPrisonerRequest.prisonerFirstName, prisonerSearchPrisoner.firstName)?.let {
-        errors.add(it)
-      }
       validateLastName(registerPrisonerRequest.prisonerLastName, prisonerSearchPrisoner.lastName)?.let {
         errors.add(it)
       }
@@ -49,15 +46,6 @@ class RegisterPrisonerValidator(private val stringInputUtils: StringInputUtils) 
     }
 
     return errors.toList()
-  }
-
-  private fun validateFirstName(
-    prisonerToRegisterFirstName: String,
-    prisonerSearchFirstName: String?,
-  ): RegisterPrisonerValidationError? = if (!areNamesMatching(prisonerToRegisterFirstName, prisonerSearchFirstName)) {
-    RegisterPrisonerValidationError.FIRST_NAME_INCORRECT
-  } else {
-    null
   }
 
   private fun validateLastName(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/RegisterPrisonerValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/RegisterPrisonerValidatorTest.kt
@@ -152,9 +152,8 @@ class RegisterPrisonerValidatorTest {
 
     val errors = registerPrisonerValidator.validateAgainstPrisonerSearch(registerPrisonerRequestDto, prisonerDto)
     Assertions.assertThat(errors).isNotEmpty()
-    Assertions.assertThat(errors.size).isEqualTo(4)
+    Assertions.assertThat(errors.size).isEqualTo(3)
     Assertions.assertThat(errors).containsExactlyInAnyOrder(
-      RegisterPrisonerValidationError.FIRST_NAME_INCORRECT,
       RegisterPrisonerValidationError.LAST_NAME_INCORRECT,
       RegisterPrisonerValidationError.DOB_INCORRECT,
       RegisterPrisonerValidationError.PRISON_CODE_INCORRECT,
@@ -182,9 +181,8 @@ class RegisterPrisonerValidatorTest {
 
     val errors = registerPrisonerValidator.validateAgainstPrisonerSearch(registerPrisonerRequestDto, prisonerDto)
     Assertions.assertThat(errors).isNotEmpty()
-    Assertions.assertThat(errors.size).isEqualTo(4)
+    Assertions.assertThat(errors.size).isEqualTo(3)
     Assertions.assertThat(errors).containsExactlyInAnyOrder(
-      RegisterPrisonerValidationError.FIRST_NAME_INCORRECT,
       RegisterPrisonerValidationError.LAST_NAME_INCORRECT,
       RegisterPrisonerValidationError.DOB_INCORRECT,
       RegisterPrisonerValidationError.PRISON_CODE_INCORRECT,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/RegisterPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/RegisterPrisonerTest.kt
@@ -20,7 +20,6 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.Booker
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.REGISTER_PRISONER_SEARCH
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.RegisterPrisonerValidationError.BOOKER_ALREADY_HAS_A_PRISONER
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.RegisterPrisonerValidationError.DOB_INCORRECT
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.RegisterPrisonerValidationError.FIRST_NAME_INCORRECT
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.RegisterPrisonerValidationError.LAST_NAME_INCORRECT
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.RegisterPrisonerValidationError.PRISONER_ALREADY_REGISTERED_AGAINST_BOOKER
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.RegisterPrisonerValidationError.PRISONER_NOT_FOUND
@@ -232,7 +231,7 @@ class RegisterPrisonerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when register prisoner does not match the prisoner is not registered against the booker and fails with a validation error`() {
+  fun `when register prisoner first-name does not match the prisoner is still registered against the booker`() {
     val registerPrisoner = RegisterPrisonerRequestDto(
       prisonerId = prisonerId,
       prisonCode = prisonCode,
@@ -256,21 +255,11 @@ class RegisterPrisonerTest : IntegrationTestBase() {
     val responseSpec = callRegisterPrisoner(orchestrationServiceRoleHttpHeaders, registerPrisoner, booker.reference)
 
     // Then
-    assertError(
-      responseSpec,
-      "Prisoner registration validation failed",
-      "Prisoner registration validation failed with the following errors - FIRST_NAME_INCORRECT",
-      HttpStatus.UNPROCESSABLE_CONTENT,
-    )
+    responseSpec.expectStatus().isCreated
 
+    verify(bookerAuditRepositorySpy, times(2)).saveAndFlush(any<BookerAudit>())
     verify(prisonerOffenderSearchClientSpy, times(1)).getPrisonerById(prisonerId)
-    verify(bookerAuditRepositorySpy, times(1)).saveAndFlush(any<BookerAudit>())
-    verify(prisonerOffenderSearchClientSpy, times(1)).getPrisonerById(prisonerId)
-    verify(telemetryClientSpy, times(0)).trackEvent(any(), any(), any())
 
-    val auditEvents = bookerAuditRepository.findAll()
-    assertThat(auditEvents).hasSize(1)
-    assertAuditEvent(auditEvents[0], booker.reference, REGISTER_PRISONER_SEARCH, "Prisoner search for prisonNumber - ${registerPrisoner.prisonerId}, firstName: ${registerPrisoner.prisonerFirstName}, lastName: ${registerPrisoner.prisonerLastName}, DOB: ${registerPrisoner.prisonerDateOfBirth}, prisonCode: ${registerPrisoner.prisonCode} failed with errors - FIRST_NAME_INCORRECT")
     verify(telemetryClientSpy, times(1)).trackEvent(
       REGISTER_PRISONER_SEARCH.telemetryEventName,
       mapOf(
@@ -280,11 +269,23 @@ class RegisterPrisonerTest : IntegrationTestBase() {
         "lastNameEntered" to registerPrisoner.prisonerLastName,
         "dobEntered" to registerPrisoner.prisonerDateOfBirth.toString(),
         "prisonCodeEntered" to registerPrisoner.prisonCode,
-        "success" to false.toString(),
-        "failureReasons" to FIRST_NAME_INCORRECT.telemetryEventName,
+        "success" to true.toString(),
       ),
       null,
     )
+
+    verify(telemetryClientSpy, times(1)).trackEvent(
+      PRISONER_REGISTERED.telemetryEventName,
+      mapOf(
+        "bookerReference" to booker.reference,
+        "prisonerId" to registerPrisoner.prisonerId,
+      ),
+      null,
+    )
+    val auditEvents = bookerAuditRepository.findAll()
+    assertThat(auditEvents).hasSize(2)
+    assertAuditEvent(auditEvents[0], booker.reference, REGISTER_PRISONER_SEARCH, "Prisoner search for prisonNumber - ${registerPrisoner.prisonerId}, firstName: ${registerPrisoner.prisonerFirstName}, lastName: ${registerPrisoner.prisonerLastName}, DOB: ${registerPrisoner.prisonerDateOfBirth}, prisonCode: ${registerPrisoner.prisonCode} was successful")
+    assertAuditEvent(auditEvents[1], booker.reference, PRISONER_REGISTERED, "Prisoner with prisonNumber - ${registerPrisoner.prisonerId} registered against booker")
   }
 
   @Test
@@ -315,7 +316,7 @@ class RegisterPrisonerTest : IntegrationTestBase() {
     assertError(
       responseSpec,
       "Prisoner registration validation failed",
-      "Prisoner registration validation failed with the following errors - FIRST_NAME_INCORRECT, LAST_NAME_INCORRECT, DOB_INCORRECT",
+      "Prisoner registration validation failed with the following errors - LAST_NAME_INCORRECT, DOB_INCORRECT",
       HttpStatus.UNPROCESSABLE_CONTENT,
     )
 
@@ -326,7 +327,7 @@ class RegisterPrisonerTest : IntegrationTestBase() {
 
     val auditEvents = bookerAuditRepository.findAll()
     assertThat(auditEvents).hasSize(1)
-    assertAuditEvent(auditEvents[0], booker.reference, REGISTER_PRISONER_SEARCH, "Prisoner search for prisonNumber - ${registerPrisoner.prisonerId}, firstName: ${registerPrisoner.prisonerFirstName}, lastName: ${registerPrisoner.prisonerLastName}, DOB: ${registerPrisoner.prisonerDateOfBirth}, prisonCode: ${registerPrisoner.prisonCode} failed with errors - FIRST_NAME_INCORRECT, LAST_NAME_INCORRECT, DOB_INCORRECT")
+    assertAuditEvent(auditEvents[0], booker.reference, REGISTER_PRISONER_SEARCH, "Prisoner search for prisonNumber - ${registerPrisoner.prisonerId}, firstName: ${registerPrisoner.prisonerFirstName}, lastName: ${registerPrisoner.prisonerLastName}, DOB: ${registerPrisoner.prisonerDateOfBirth}, prisonCode: ${registerPrisoner.prisonCode} failed with errors - LAST_NAME_INCORRECT, DOB_INCORRECT")
     verify(telemetryClientSpy, times(1)).trackEvent(
       REGISTER_PRISONER_SEARCH.telemetryEventName,
       mapOf(
@@ -337,7 +338,7 @@ class RegisterPrisonerTest : IntegrationTestBase() {
         "dobEntered" to registerPrisoner.prisonerDateOfBirth.toString(),
         "prisonCodeEntered" to registerPrisoner.prisonCode,
         "success" to false.toString(),
-        "failureReasons" to "${FIRST_NAME_INCORRECT.telemetryEventName}, ${LAST_NAME_INCORRECT.telemetryEventName}, ${DOB_INCORRECT.telemetryEventName}",
+        "failureReasons" to "${LAST_NAME_INCORRECT.telemetryEventName}, ${DOB_INCORRECT.telemetryEventName}",
       ),
       null,
     )


### PR DESCRIPTION
We only want to validate against the remaining fields (such as last name, DOB and location)