### PR TITLE
VB-6593 - Allow booker to set a language preference for visitor request correspondence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/AddVisitorToBookerPrisonerRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/AddVisitorToBookerPrisonerRequestDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import java.time.LocalDate
 
 @Schema(description = "Visitor request details to add a visitor to a booker prisoner")
@@ -16,4 +17,7 @@ data class AddVisitorToBookerPrisonerRequestDto(
 
   @param:Schema(name = "dateOfBirth", description = "Date of birth of the visitor in request", required = true)
   val dateOfBirth: LocalDate,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", defaultValue = "EN", required = false)
+  val languagePreference: LanguagePreference = LanguagePreference.EN,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/BookerPrisonerVisitorRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/BookerPrisonerVisitorRequestDto.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.VisitorRequest
 import java.time.LocalDate
 
@@ -35,6 +36,9 @@ data class BookerPrisonerVisitorRequestDto(
 
   @param:Schema(description = "Date when the visitor request was added", example = "2026-05-01", required = true)
   val requestedOn: LocalDate,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = true)
+  val languagePreference: LanguagePreference,
 ) {
   constructor(visitorRequest: VisitorRequest) : this(
     reference = visitorRequest.reference,
@@ -45,5 +49,6 @@ data class BookerPrisonerVisitorRequestDto(
     dateOfBirth = visitorRequest.dateOfBirth,
     status = visitorRequest.status,
     requestedOn = visitorRequest.createTimestamp!!.toLocalDate(),
+    languagePreference = visitorRequest.languagePreference,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/CreateVisitorRequestResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/CreateVisitorRequestResponseDto.kt
@@ -23,6 +23,6 @@ data class CreateVisitorRequestResponseDto(
   @param:Schema(description = "Identifier for a matched contact (Person in NOMIS), NULL if an automatic match for the visitor request was not found", required = false)
   val visitorId: Long?,
 
-  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = false)
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = true)
   val languagePreference: LanguagePreference,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/CreateVisitorRequestResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/CreateVisitorRequestResponseDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 
 data class CreateVisitorRequestResponseDto(
   @param:Schema(description = "Reference of newly created visitor request", example = "abc-def-ghi")
@@ -21,4 +22,7 @@ data class CreateVisitorRequestResponseDto(
 
   @param:Schema(description = "Identifier for a matched contact (Person in NOMIS), NULL if an automatic match for the visitor request was not found", required = false)
   val visitorId: Long?,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = false)
+  val languagePreference: LanguagePreference,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/PrisonVisitorRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/PrisonVisitorRequestDto.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestRejectionReason
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.VisitorRequest
 import java.time.LocalDate
 
@@ -46,6 +47,9 @@ data class PrisonVisitorRequestDto(
 
   @param:Schema(description = "The current status of the request", example = "REQUESTED", required = true)
   val status: VisitorRequestsStatus,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = true)
+  val languagePreference: LanguagePreference,
 ) {
   constructor(visitorRequest: VisitorRequest, bookerEmail: String) : this(
     reference = visitorRequest.reference,
@@ -59,5 +63,6 @@ data class PrisonVisitorRequestDto(
     visitorId = visitorRequest.visitorId,
     rejectionReason = visitorRequest.rejectionReason,
     status = visitorRequest.status,
+    languagePreference = visitorRequest.languagePreference,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/enums/LanguagePreference.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/enums/LanguagePreference.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums
+
+@Suppress("unused")
+enum class LanguagePreference {
+  EN,
+  CY,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/entity/VisitorRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/entity/VisitorRequest.kt
@@ -14,6 +14,7 @@ import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestRejectionReason
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.utils.QuotableEncoder
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -51,6 +52,10 @@ class VisitorRequest(
   @Enumerated(EnumType.STRING)
   @Column
   val rejectionReason: VisitorRequestRejectionReason? = null,
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  val languagePreference: LanguagePreference,
 ) {
   @Column
   var reference: String = ""

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerAuditService.kt
@@ -6,12 +6,8 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.CreateVisitorRequestResponseDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.ACTIVATED_PRISONER
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.ACTIVATED_VISITOR
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.BOOKER_CREATED
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.CLEAR_BOOKER_DETAILS
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.DEACTIVATED_PRISONER
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.DEACTIVATED_VISITOR
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.PRISONER_REGISTERED
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.REGISTER_PRISONER_SEARCH
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType.UPDATE_BOOKER_EMAIL
@@ -44,6 +40,7 @@ class BookerAuditService(
     private const val REGISTERED_PRISON_CODE = "prisonId"
     private const val VISITOR_REQUEST_STATUS = "visitorRequestStatus"
     private const val ACTIONED_BY = "actionedBy"
+    private const val LANGUAGE_PREFERENCE = "languagePreference"
 
     private interface PrisonerSearchPropertyNames {
       companion object {
@@ -75,32 +72,6 @@ class BookerAuditService(
   fun auditAddPrisoner(bookerReference: String, prisonNumber: String) {
     val auditType = PRISONER_REGISTERED
     val text = "Prisoner with prisonNumber - $prisonNumber registered against booker"
-    auditBookerEvent(bookerReference, auditType, text)
-
-    // send event to telemetry client
-    val properties = mapOf(
-      BOOKER_REFERENCE_PROPERTY_NAME to bookerReference,
-      PRISON_NUMBER_PROPERTY_NAME to prisonNumber,
-    )
-    sendTelemetryClientEvent(auditType, properties)
-  }
-
-  fun auditActivatePrisoner(bookerReference: String, prisonNumber: String) {
-    val auditType = ACTIVATED_PRISONER
-    val text = "Prisoner with prisonNumber - $prisonNumber activated"
-
-    auditBookerEvent(bookerReference, auditType, text)
-    // send event to telemetry client
-    val properties = mapOf(
-      BOOKER_REFERENCE_PROPERTY_NAME to bookerReference,
-      PRISON_NUMBER_PROPERTY_NAME to prisonNumber,
-    )
-    sendTelemetryClientEvent(auditType, properties)
-  }
-
-  fun auditDeactivatePrisoner(bookerReference: String, prisonNumber: String) {
-    val auditType = DEACTIVATED_PRISONER
-    val text = "Prisoner with prisonNumber - $prisonNumber deactivated"
     auditBookerEvent(bookerReference, auditType, text)
 
     // send event to telemetry client
@@ -162,20 +133,6 @@ class BookerAuditService(
     sendTelemetryClientEvent(auditType, properties)
   }
 
-  fun auditActivateVisitor(bookerReference: String, visitorId: Long, prisonNumber: String) {
-    val auditType = ACTIVATED_VISITOR
-    val text = "Visitor ID - $visitorId activated for prisoner - $prisonNumber"
-    auditBookerEvent(bookerReference, auditType, text)
-
-    // send event to telemetry client
-    val properties = mapOf(
-      BOOKER_REFERENCE_PROPERTY_NAME to bookerReference,
-      PRISON_NUMBER_PROPERTY_NAME to prisonNumber,
-      VISITOR_ID_PROPERTY_NAME to visitorId.toString(),
-    )
-    sendTelemetryClientEvent(auditType, properties)
-  }
-
   fun auditVisitorRequest(createVisitorRequestResponseDto: CreateVisitorRequestResponseDto) {
     val auditType = BookerAuditType.VISITOR_REQUEST_SUBMITTED
     val text = "Booker ${createVisitorRequestResponseDto.bookerReference}, submitted request to add visitor to prisoner ${createVisitorRequestResponseDto.prisonerId}, request reference - ${createVisitorRequestResponseDto.reference}"
@@ -193,6 +150,7 @@ class BookerAuditService(
       VISITOR_REQUEST_REFERENCE to createVisitorRequestResponseDto.reference,
       VISITOR_REQUEST_STATUS to createVisitorRequestResponseDto.status.name,
       REGISTERED_PRISON_CODE to createVisitorRequestResponseDto.prisonId,
+      LANGUAGE_PREFERENCE to createVisitorRequestResponseDto.languagePreference.name,
     )
 
     // set the matched visitorId if it exists
@@ -200,20 +158,6 @@ class BookerAuditService(
       properties[VISITOR_ID_PROPERTY_NAME] = it.toString()
     }
 
-    sendTelemetryClientEvent(auditType, properties)
-  }
-
-  fun auditDeactivateVisitor(bookerReference: String, visitorId: Long, prisonNumber: String) {
-    val auditType = DEACTIVATED_VISITOR
-    val text = "Visitor ID - $visitorId deactivated for prisoner - $prisonNumber"
-    auditBookerEvent(bookerReference, DEACTIVATED_VISITOR, text)
-
-    // send event to telemetry client
-    val properties = mapOf(
-      BOOKER_REFERENCE_PROPERTY_NAME to bookerReference,
-      PRISON_NUMBER_PROPERTY_NAME to prisonNumber,
-      VISITOR_ID_PROPERTY_NAME to visitorId.toString(),
-    )
     sendTelemetryClientEvent(auditType, properties)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
@@ -75,6 +75,7 @@ class VisitorRequestsStoreService(
         dateOfBirth = request.dateOfBirth,
         status = visitorRequestStatus, // REQUESTED or AUTO_APPROVED
         visitorId = if (!multipleMatches) matchingContact?.personId else null,
+        languagePreference = request.languagePreference,
       ),
     )
 
@@ -88,6 +89,7 @@ class VisitorRequestsStoreService(
       prisonerId = prisonerId,
       prisonId = prisonerRegisteredPrisonCode,
       visitorId = if (!multipleMatches) matchingContact?.personId else null,
+      languagePreference = savedVisitorRequest.languagePreference,
     )
   }
 

--- a/src/main/resources/db/migration/V2_5__add_language_preference_to_visitor_requests.sql
+++ b/src/main/resources/db/migration/V2_5__add_language_preference_to_visitor_requests.sql
@@ -1,0 +1,2 @@
+ALTER TABLE visitor_requests
+    ADD COLUMN language_preference VARCHAR(2) NOT NULL DEFAULT 'EN';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/ActiveVisitorRequestsForBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/ActiveVisitorRequestsForBookerTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.controller.GET_V
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.AddVisitorToBookerPrisonerRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.BookerPrisonerVisitorRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Booker
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.VisitorRequest
 import java.time.LocalDate
@@ -34,14 +35,14 @@ class ActiveVisitorRequestsForBookerTest : IntegrationTestBase() {
   fun `when get active visitor requests by booker reference is called only REQUESTED status requests are returned`() {
     // Given
     val bookerReference = booker1.reference
-    val request1 = createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)), status = VisitorRequestsStatus.REQUESTED)
+    val request1 = createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)), status = VisitorRequestsStatus.REQUESTED, LanguagePreference.EN)
     // status not REQUESTED
-    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(22)), status = VisitorRequestsStatus.APPROVED)
+    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(22)), status = VisitorRequestsStatus.APPROVED, LanguagePreference.EN)
     // status not REQUESTED
     createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName3", "lastName3", LocalDate.now().minusYears(23)), status = VisitorRequestsStatus.REJECTED)
-    val request4 = createVisitorRequest(booker1.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED)
+    val request4 = createVisitorRequest(booker1.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED, LanguagePreference.CY)
     // same prisoner REQUESTED - but other booker
-    createVisitorRequest(booker2.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED)
+    createVisitorRequest(booker2.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED, LanguagePreference.CY)
 
     // When
     val responseSpec = getActiveVisitorRequestsByBookerReference(webTestClient, bookerReference, orchestrationServiceRoleHttpHeaders)
@@ -65,11 +66,11 @@ class ActiveVisitorRequestsForBookerTest : IntegrationTestBase() {
     val bookerReference = booker1.reference
 
     // status not REQUESTED
-    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(22)), status = VisitorRequestsStatus.APPROVED)
+    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(22)), status = VisitorRequestsStatus.APPROVED, LanguagePreference.EN)
     // status not REQUESTED
-    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName3", "lastName3", LocalDate.now().minusYears(23)), status = VisitorRequestsStatus.REJECTED)
+    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName3", "lastName3", LocalDate.now().minusYears(23)), status = VisitorRequestsStatus.REJECTED, LanguagePreference.EN)
     // for other booker
-    createVisitorRequest(booker2.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED)
+    createVisitorRequest(booker2.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED, LanguagePreference.EN)
 
     // When
     val responseSpec = getActiveVisitorRequestsByBookerReference(webTestClient, bookerReference, orchestrationServiceRoleHttpHeaders)
@@ -110,6 +111,7 @@ class ActiveVisitorRequestsForBookerTest : IntegrationTestBase() {
     Assertions.assertThat(visitorRequestDto.dateOfBirth).isEqualTo(visitorRequest.dateOfBirth)
     Assertions.assertThat(visitorRequestDto.status).isEqualTo(visitorRequest.status)
     Assertions.assertThat(visitorRequestDto.requestedOn).isEqualTo(visitorRequest.createTimestamp!!.toLocalDate())
+    Assertions.assertThat(visitorRequestDto.languagePreference).isEqualTo(visitorRequest.languagePreference)
   }
 
   fun getActiveVisitorRequestsByBookerReference(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/ActiveVisitorRequestsForBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/ActiveVisitorRequestsForBookerTest.kt
@@ -35,14 +35,14 @@ class ActiveVisitorRequestsForBookerTest : IntegrationTestBase() {
   fun `when get active visitor requests by booker reference is called only REQUESTED status requests are returned`() {
     // Given
     val bookerReference = booker1.reference
-    val request1 = createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)), status = VisitorRequestsStatus.REQUESTED, LanguagePreference.EN)
+    val request1 = createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)), status = VisitorRequestsStatus.REQUESTED, languagePreference = LanguagePreference.EN)
     // status not REQUESTED
-    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(22)), status = VisitorRequestsStatus.APPROVED, LanguagePreference.EN)
+    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(22)), status = VisitorRequestsStatus.APPROVED, languagePreference = LanguagePreference.EN)
     // status not REQUESTED
     createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName3", "lastName3", LocalDate.now().minusYears(23)), status = VisitorRequestsStatus.REJECTED)
-    val request4 = createVisitorRequest(booker1.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED, LanguagePreference.CY)
+    val request4 = createVisitorRequest(booker1.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED, languagePreference = LanguagePreference.CY)
     // same prisoner REQUESTED - but other booker
-    createVisitorRequest(booker2.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED, LanguagePreference.CY)
+    createVisitorRequest(booker2.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED, languagePreference = LanguagePreference.CY)
 
     // When
     val responseSpec = getActiveVisitorRequestsByBookerReference(webTestClient, bookerReference, orchestrationServiceRoleHttpHeaders)
@@ -66,11 +66,11 @@ class ActiveVisitorRequestsForBookerTest : IntegrationTestBase() {
     val bookerReference = booker1.reference
 
     // status not REQUESTED
-    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(22)), status = VisitorRequestsStatus.APPROVED, LanguagePreference.EN)
+    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(22)), status = VisitorRequestsStatus.APPROVED, languagePreference = LanguagePreference.EN)
     // status not REQUESTED
-    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName3", "lastName3", LocalDate.now().minusYears(23)), status = VisitorRequestsStatus.REJECTED, LanguagePreference.EN)
+    createVisitorRequest(booker1.reference, "A1234", AddVisitorToBookerPrisonerRequestDto("firstName3", "lastName3", LocalDate.now().minusYears(23)), status = VisitorRequestsStatus.REJECTED, languagePreference = LanguagePreference.EN)
     // for other booker
-    createVisitorRequest(booker2.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED, LanguagePreference.EN)
+    createVisitorRequest(booker2.reference, "A1233", AddVisitorToBookerPrisonerRequestDto("firstName4", "lastName4", LocalDate.now().minusYears(24)), status = VisitorRequestsStatus.REQUESTED, languagePreference = LanguagePreference.EN)
 
     // When
     val responseSpec = getActiveVisitorRequestsByBookerReference(webTestClient, bookerReference, orchestrationServiceRoleHttpHeaders)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/GetSingleVisitorRequestForBookerPrisonerByReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/GetSingleVisitorRequestForBookerPrisonerByReferenceTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.controller.GET_S
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.AddVisitorToBookerPrisonerRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonVisitorRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import java.time.LocalDate
 
 @Transactional(propagation = SUPPORTS)
@@ -24,7 +25,7 @@ class GetSingleVisitorRequestForBookerPrisonerByReferenceTest : IntegrationTestB
     val prisonCode = "HEI"
     val booker = createBooker("one-sub", "test@test.com")
     val prisoner = createPrisoner(booker, "AA123456", prisonCode)
-    val request = createVisitorRequest(booker.reference, prisoner.prisonerId, AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)), status = VisitorRequestsStatus.REQUESTED)
+    val request = createVisitorRequest(booker.reference, prisoner.prisonerId, AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)), status = VisitorRequestsStatus.REQUESTED, languagePreference = LanguagePreference.EN)
 
     // When
     val responseSpec = callGetSingleVisitorRequest(webTestClient, request.reference, bookerConfigServiceRoleHttpHeaders)
@@ -36,6 +37,7 @@ class GetSingleVisitorRequestForBookerPrisonerByReferenceTest : IntegrationTestB
     Assertions.assertThat(singleRequest.prisonerId).isEqualTo(prisoner.prisonerId)
     Assertions.assertThat(singleRequest.reference).isEqualTo(request.reference)
     Assertions.assertThat(singleRequest.requestedOn).isEqualTo(LocalDate.now())
+    Assertions.assertThat(singleRequest.languagePreference).isEqualTo(request.languagePreference)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/GetVisitorRequestsForPrisonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/GetVisitorRequestsForPrisonTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.controller.GET_V
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.AddVisitorToBookerPrisonerRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonVisitorRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import java.time.LocalDate
 
 @Transactional(propagation = Propagation.SUPPORTS)
@@ -33,18 +34,21 @@ class GetVisitorRequestsForPrisonTest : IntegrationTestBase() {
       prisoner.prisonerId,
       AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)),
       status = VisitorRequestsStatus.REQUESTED,
+      languagePreference = LanguagePreference.EN,
     )
     createVisitorRequest(
       booker.reference,
       prisoner.prisonerId,
       AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(21)),
       status = VisitorRequestsStatus.APPROVED,
+      languagePreference = LanguagePreference.EN,
     )
     createVisitorRequest(
       booker.reference,
       otherPrisoner.prisonerId,
       AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)),
       status = VisitorRequestsStatus.REQUESTED,
+      languagePreference = LanguagePreference.EN,
     )
 
     // When
@@ -61,6 +65,7 @@ class GetVisitorRequestsForPrisonTest : IntegrationTestBase() {
     Assertions.assertThat(responseDto[0].lastName).isEqualTo("lastName1")
     Assertions.assertThat(responseDto[0].dateOfBirth).isEqualTo(LocalDate.now().minusYears(21))
     Assertions.assertThat(responseDto[0].requestedOn).isEqualTo(LocalDate.now())
+    Assertions.assertThat(responseDto[0].languagePreference).isEqualTo(LanguagePreference.EN)
   }
 
   @Test
@@ -95,12 +100,14 @@ class GetVisitorRequestsForPrisonTest : IntegrationTestBase() {
       prisoner.prisonerId,
       AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)),
       status = VisitorRequestsStatus.REQUESTED,
+      languagePreference = LanguagePreference.CY,
     )
     createVisitorRequest(
       booker1.reference,
       prisoner.prisonerId,
       AddVisitorToBookerPrisonerRequestDto("firstName2", "lastName2", LocalDate.now().minusYears(21)),
       status = VisitorRequestsStatus.APPROVED,
+      languagePreference = LanguagePreference.CY,
     )
 
     // When
@@ -113,6 +120,7 @@ class GetVisitorRequestsForPrisonTest : IntegrationTestBase() {
     Assertions.assertThat(responseDto.size).isEqualTo(1)
     Assertions.assertThat(responseDto[0].prisonerId).isEqualTo(prisoner.prisonerId)
     Assertions.assertThat(responseDto[0].bookerReference).isEqualTo(prisoner.booker.reference)
+    Assertions.assertThat(responseDto[0].languagePreference).isEqualTo(LanguagePreference.CY)
 
     // When
     responseSpec = getVisitorRequestsByPrisonCode(webTestClient, otherPrisonCode, orchestrationServiceRoleHttpHeaders)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/IntegrationTestBase.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.RegisterPris
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.prisoner.search.PrisonerDto
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration.helper.EntityHelper
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration.helper.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration.mock.HmppsAuthExtension
@@ -136,7 +137,7 @@ abstract class IntegrationTestBase {
   }
   fun createPrisoner(booker: Booker, prisonerId: String, prisonCode: String = PRISON_CODE): PermittedPrisoner = entityHelper.createAssociatedPrisoner(PermittedPrisoner(bookerId = booker.id, booker = booker, prisonerId = prisonerId, prisonCode = prisonCode))
 
-  fun createVisitorRequest(bookerReference: String, prisonerId: String, addVisitorToBookerPrisonerRequestDto: AddVisitorToBookerPrisonerRequestDto, status: VisitorRequestsStatus): VisitorRequest = entityHelper.createVisitorRequest(
+  fun createVisitorRequest(bookerReference: String, prisonerId: String, addVisitorToBookerPrisonerRequestDto: AddVisitorToBookerPrisonerRequestDto, status: VisitorRequestsStatus, languagePreference: LanguagePreference = LanguagePreference.EN): VisitorRequest = entityHelper.createVisitorRequest(
     VisitorRequest(
       bookerReference = bookerReference,
       prisonerId = prisonerId,
@@ -144,6 +145,7 @@ abstract class IntegrationTestBase {
       lastName = addVisitorToBookerPrisonerRequestDto.lastName,
       dateOfBirth = addVisitorToBookerPrisonerRequestDto.dateOfBirth,
       status = status,
+      languagePreference = languagePreference,
     ),
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/SubmitVisitorRequestAddVisitorToBookerPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/SubmitVisitorRequestAddVisitorToBookerPrisonerTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.AddVisitorTo
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.BookerAuditType
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.VisitorRequest
 import java.time.LocalDate
 
@@ -41,6 +42,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
     )
 
     // When
@@ -65,6 +67,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
         "requestReference" to visitRequest.reference,
         "visitorRequestStatus" to visitRequest.status.name,
         "prisonId" to prisoner.prisonCode,
+        "languagePreference" to LanguagePreference.EN.name,
       ),
       null,
     )
@@ -83,6 +86,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.CY,
     )
 
     // When
@@ -107,6 +111,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
         "visitorRequestStatus" to visitRequest.status.name,
         "prisonId" to prisoner.prisonCode,
         "visitorId" to prisonerContact.personId.toString(),
+        "languagePreference" to LanguagePreference.CY.name,
       ),
       null,
     )
@@ -126,6 +131,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
     )
 
     // When
@@ -151,6 +157,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
         "visitorRequestStatus" to visitRequest.status.name,
         "prisonId" to prisoner.prisonCode,
         "visitorId" to prisonerContactUnapproved.personId.toString(),
+        "languagePreference" to LanguagePreference.EN.name,
       ),
       null,
     )
@@ -170,6 +177,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = " JoHñ ",
       lastName = " SmIțH ",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
     )
 
     // When
@@ -194,6 +202,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
         "visitorRequestStatus" to visitRequest.status.name,
         "prisonId" to prisoner.prisonCode,
         "visitorId" to prisonerContact.personId.toString(),
+        "languagePreference" to LanguagePreference.EN.name,
       ),
       null,
     )
@@ -213,6 +222,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = " JoHn ",
       lastName = " SmItH ",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
     )
 
     // When
@@ -237,6 +247,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
         "visitorRequestStatus" to visitRequest.status.name,
         "prisonId" to prisoner.prisonCode,
         "visitorId" to prisonerContact.personId.toString(),
+        "languagePreference" to LanguagePreference.EN.name,
       ),
       null,
     )
@@ -256,6 +267,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.CY,
     )
 
     // When
@@ -283,6 +295,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.CY,
     )
 
     // When
@@ -309,6 +322,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
         "requestReference" to visitRequest.reference,
         "visitorRequestStatus" to visitRequest.status.name,
         "prisonId" to prisoner.prisonCode,
+        "languagePreference" to LanguagePreference.CY.name,
       ),
       null,
     )
@@ -334,6 +348,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.CY,
     )
 
     // When
@@ -363,6 +378,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "firstName",
       lastName = "lastName",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
     )
 
     // When
@@ -391,6 +407,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
     )
 
     // When
@@ -419,6 +436,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
     )
 
     // When
@@ -445,6 +463,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
     )
 
     // When
@@ -471,6 +490,7 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
       firstName = "John",
       lastName = "Smith",
       dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
     )
     // When
     val responseSpec = callSubmitVisitorRequest(setAuthorisation(roles = listOf()), bookerReference, prisonerId, visitorRequestDto)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/events/EventsIntegrationTestBase.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.TestObjectMapper
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.client.PrisonerContactRegistryClient
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.AddVisitorToBookerPrisonerRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestsStatus
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration.IntegrationTestBase.Companion.PRISON_CODE
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration.events.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration.helper.EntityHelper
@@ -189,7 +190,7 @@ abstract class EventsIntegrationTestBase {
   }
   fun createPrisoner(booker: Booker, prisonerId: String, prisonCode: String = PRISON_CODE): PermittedPrisoner = entityHelper.createAssociatedPrisoner(PermittedPrisoner(bookerId = booker.id, booker = booker, prisonerId = prisonerId, prisonCode = prisonCode))
 
-  fun createVisitorRequest(bookerReference: String, prisonerId: String, addVisitorToBookerPrisonerRequestDto: AddVisitorToBookerPrisonerRequestDto, status: VisitorRequestsStatus): VisitorRequest = entityHelper.createVisitorRequest(
+  fun createVisitorRequest(bookerReference: String, prisonerId: String, addVisitorToBookerPrisonerRequestDto: AddVisitorToBookerPrisonerRequestDto, status: VisitorRequestsStatus, languagePreference: LanguagePreference = LanguagePreference.EN): VisitorRequest = entityHelper.createVisitorRequest(
     VisitorRequest(
       bookerReference = bookerReference,
       prisonerId = prisonerId,
@@ -197,6 +198,7 @@ abstract class EventsIntegrationTestBase {
       lastName = addVisitorToBookerPrisonerRequestDto.lastName,
       dateOfBirth = addVisitorToBookerPrisonerRequestDto.dateOfBirth,
       status = status,
+      languagePreference = languagePreference,
     ),
   )
 }


### PR DESCRIPTION
## What does this PR do?

Allow booker to set a language preference for visitor request correspondence. For now they'll have an option to select English EN or Welsh CY.

All tests have been updated.

## JIRA Links
https://dsdmoj.atlassian.net/browse/VB-6593
https://dsdmoj.atlassian.net/browse/VB-6745