### PR TITLE
VB-3876 - Prisoner merge pre-requisite changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedPrisonerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedPrisonerRepository.kt
@@ -10,11 +10,13 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Per
 interface PermittedPrisonerRepository : JpaRepository<PermittedPrisoner, Long> {
   fun findByBookerId(bookerId: Long): List<PermittedPrisoner>
 
+  fun existsByBookerIdAndPrisonerIdIgnoreCase(bookerId: Long, prisonerId: String): Boolean
+
   @Transactional(readOnly = true)
   @Query(
     "Select pp.* FROM permitted_prisoner pp " +
       "   LEFT JOIN booker b ON b.id = pp.booker_id " +
-      " WHERE b.reference = :bookerReference AND prisoner_id=:prisonerId",
+      " WHERE b.reference = :bookerReference AND lower(prisoner_id) = lower(:prisonerId)",
     nativeQuery = true,
   )
   fun findByBookerIdAndPrisonerId(bookerReference: String, prisonerId: String): PermittedPrisoner?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedPrisonerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedPrisonerRepository.kt
@@ -20,13 +20,4 @@ interface PermittedPrisonerRepository : JpaRepository<PermittedPrisoner, Long> {
     nativeQuery = true,
   )
   fun findByBookerIdAndPrisonerId(bookerReference: String, prisonerId: String): PermittedPrisoner?
-
-  @Transactional(readOnly = true)
-  @Query(
-    "Select pp.* FROM permitted_prisoner pp" +
-      "   LEFT JOIN booker b ON b.id = pp.booker_id " +
-      " WHERE b.referenc = :bookerReference AND prisoner_id=:prisonerId ",
-    nativeQuery = true,
-  )
-  fun getBookerPrisoner(bookerReference: String, prisonerId: String): PermittedPrisoner?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedVisitorRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedVisitorRepository.kt
@@ -13,6 +13,17 @@ interface PermittedVisitorRepository : JpaRepository<PermittedVisitor, Long> {
 
   fun existsByPermittedPrisonerIdAndVisitorId(permittedPrisonerId: Long, visitorId: Long): Boolean
 
+  @Modifying
+  @Query(
+    """
+    INSERT INTO permitted_visitor (permitted_prisoner_id, visitor_id)
+    VALUES (:permittedPrisonerId, :visitorId)
+    ON CONFLICT (permitted_prisoner_id, visitor_id) DO NOTHING
+    """,
+    nativeQuery = true,
+  )
+  fun insertIfAbsent(permittedPrisonerId: Long, visitorId: Long): Int
+
   @Transactional(readOnly = true)
   @Query(
     "Select pv.* FROM permitted_visitor pv " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedVisitorRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedVisitorRepository.kt
@@ -18,7 +18,7 @@ interface PermittedVisitorRepository : JpaRepository<PermittedVisitor, Long> {
     "Select pv.* FROM permitted_visitor pv " +
       "   LEFT JOIN permitted_prisoner pp ON pp.id = pv.permitted_prisoner_id" +
       "   LEFT JOIN booker b ON b.id = pp.booker_id " +
-      " WHERE b.reference = :bookerReference AND prisoner_id=:prisonerId AND pv.visitor_id = :visitorId",
+      " WHERE b.reference = :bookerReference AND lower(pp.prisoner_id) = lower(:prisonerId) AND pv.visitor_id = :visitorId",
     nativeQuery = true,
   )
   fun findVisitorBy(bookerReference: String, prisonerId: String, visitorId: Long): PermittedVisitor?
@@ -32,7 +32,7 @@ interface PermittedVisitorRepository : JpaRepository<PermittedVisitor, Long> {
   JOIN booker b ON b.id = pp.booker_id
   WHERE pv.permitted_prisoner_id = pp.id
     AND b.reference = :bookerReference
-    AND pp.prisoner_id = :prisonerId
+    AND lower(pp.prisoner_id) = lower(:prisonerId)
     AND pv.visitor_id = :visitorId
   """,
     nativeQuery = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedVisitorRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedVisitorRepository.kt
@@ -11,6 +11,8 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Per
 interface PermittedVisitorRepository : JpaRepository<PermittedVisitor, Long> {
   fun findByPermittedPrisonerId(prisonerPermittedId: Long): List<PermittedVisitor>
 
+  fun existsByPermittedPrisonerIdAndVisitorId(permittedPrisonerId: Long, visitorId: Long): Boolean
+
   @Transactional(readOnly = true)
   @Query(
     "Select pv.* FROM permitted_visitor pv " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedVisitorRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/model/repository/PermittedVisitorRepository.kt
@@ -13,6 +13,7 @@ interface PermittedVisitorRepository : JpaRepository<PermittedVisitor, Long> {
 
   fun existsByPermittedPrisonerIdAndVisitorId(permittedPrisonerId: Long, visitorId: Long): Boolean
 
+  @Transactional
   @Modifying
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsService.kt
@@ -29,7 +29,7 @@ class BookerDetailsService(
 
     val permittedPrisoner = bookerDetailsStoreService.storeBookerPrisoner(bookerReference, createPermittedPrisonerDto)
 
-    bookerAuditService.auditAddPrisoner(bookerReference = bookerReference, prisonNumber = createPermittedPrisonerDto.prisonerId)
+    bookerAuditService.auditAddPrisoner(bookerReference = bookerReference, prisonNumber = permittedPrisoner.prisonerId)
     LOG.info("Prisoner added to permitted prisoners for booker {}", bookerReference)
     return permittedPrisoner
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsStoreService.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Per
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.BookerRepository
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.PermittedPrisonerRepository
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.PermittedVisitorRepository
-import java.util.*
 
 @Service
 class BookerDetailsStoreService(
@@ -38,7 +37,7 @@ class BookerDetailsStoreService(
     LOG.info("Enter BookerDetailsStoreService storeBookerPrisoner for booker $bookerReference")
 
     val booker = getBooker(bookerReference)
-    val prisonerId = createPermittedPrisonerDto.prisonerId.trim().uppercase(Locale.ROOT)
+    val prisonerId = createPermittedPrisonerDto.prisonerId.trim().uppercase()
     if (prisonerRepository.existsByBookerIdAndPrisonerIdIgnoreCase(booker.id, prisonerId)) {
       LOG.error("Prisoner already exists for booker $bookerReference")
       throw BookerPrisonerAlreadyExistsException("BookerPrisoner for $bookerReference already exists")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsStoreService.kt
@@ -37,7 +37,7 @@ class BookerDetailsStoreService(
     LOG.info("Enter BookerDetailsStoreService storeBookerPrisoner for booker $bookerReference")
 
     val booker = getBooker(bookerReference)
-    if (booker.permittedPrisoners.any { createPermittedPrisonerDto.prisonerId == it.prisonerId }) {
+    if (prisonerRepository.existsByBookerIdAndPrisonerIdIgnoreCase(booker.id, createPermittedPrisonerDto.prisonerId)) {
       LOG.error("Prisoner already exists for booker $bookerReference")
       throw BookerPrisonerAlreadyExistsException("BookerPrisoner for $bookerReference already exists")
     }
@@ -99,7 +99,7 @@ class BookerDetailsStoreService(
 
     val bookerPrisoner = getPermittedPrisoner(bookerReference, prisonerId)
 
-    if (bookerPrisoner.permittedVisitors.any { visitorId == it.visitorId }) {
+    if (visitorRepository.existsByPermittedPrisonerIdAndVisitorId(bookerPrisoner.id, visitorId)) {
       LOG.warn("Visitor  $visitorId already exists for booker $bookerReference prisoner $prisonerId")
       return PermittedVisitorDto(
         visitorId = visitorId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/BookerDetailsStoreService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service
 
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.BookerDto
@@ -15,10 +16,10 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.Update
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.VisitorForPrisonerBookerNotFoundException
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Booker
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.PermittedPrisoner
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.PermittedVisitor
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.BookerRepository
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.PermittedPrisonerRepository
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.PermittedVisitorRepository
+import java.util.*
 
 @Service
 class BookerDetailsStoreService(
@@ -37,24 +38,34 @@ class BookerDetailsStoreService(
     LOG.info("Enter BookerDetailsStoreService storeBookerPrisoner for booker $bookerReference")
 
     val booker = getBooker(bookerReference)
-    if (prisonerRepository.existsByBookerIdAndPrisonerIdIgnoreCase(booker.id, createPermittedPrisonerDto.prisonerId)) {
+    val prisonerId = createPermittedPrisonerDto.prisonerId.trim().uppercase(Locale.ROOT)
+    if (prisonerRepository.existsByBookerIdAndPrisonerIdIgnoreCase(booker.id, prisonerId)) {
       LOG.error("Prisoner already exists for booker $bookerReference")
       throw BookerPrisonerAlreadyExistsException("BookerPrisoner for $bookerReference already exists")
     }
 
-    val permittedPrisoner = prisonerRepository.saveAndFlush(
-      PermittedPrisoner(
-        bookerId = booker.id,
-        booker = booker,
-        prisonerId = createPermittedPrisonerDto.prisonerId,
-        prisonCode = createPermittedPrisonerDto.prisonCode,
-      ),
-    )
+    try {
+      val permittedPrisoner = prisonerRepository.saveAndFlush(
+        PermittedPrisoner(
+          bookerId = booker.id,
+          booker = booker,
+          prisonerId = prisonerId,
+          prisonCode = createPermittedPrisonerDto.prisonCode,
+        ),
+      )
 
-    booker.permittedPrisoners.add(permittedPrisoner)
+      booker.permittedPrisoners.add(permittedPrisoner)
 
-    LOG.info("Prisoner added to permitted prisoners for booker $bookerReference")
-    return PermittedPrisonerDto(permittedPrisoner)
+      LOG.info("Prisoner added to permitted prisoners for booker $bookerReference")
+      return PermittedPrisonerDto(permittedPrisoner)
+    } catch (e: DataIntegrityViolationException) {
+      if (e.isUniqueViolationFor(PERMITTED_PRISONER_BOOKER_PRISONER_UNIQUE_INDEX)) {
+        LOG.error("Prisoner already exists for booker $bookerReference after concurrent insert")
+        throw BookerPrisonerAlreadyExistsException("BookerPrisoner for $bookerReference already exists")
+      }
+
+      throw e
+    }
   }
 
   @Transactional
@@ -106,18 +117,14 @@ class BookerDetailsStoreService(
       )
     }
 
-    val permittedVisitor = visitorRepository.saveAndFlush(
-      PermittedVisitor(
-        permittedPrisonerId = bookerPrisoner.id,
-        permittedPrisoner = bookerPrisoner,
-        visitorId = visitorId,
-      ),
-    )
-    bookerPrisoner.permittedVisitors.add(permittedVisitor)
+    val insertedRows = visitorRepository.insertIfAbsent(bookerPrisoner.id, visitorId)
+    if (insertedRows == 1) {
+      LOG.info("Visitor $visitorId added to permitted visitors for booker $bookerReference prisoner $prisonerId")
+    } else {
+      LOG.warn("Visitor $visitorId already exists for booker $bookerReference prisoner $prisonerId after concurrent insert")
+    }
 
-    LOG.info("Visitor $visitorId added to permitted visitors for booker $bookerReference prisoner $prisonerId")
-
-    return PermittedVisitorDto(permittedVisitor)
+    return PermittedVisitorDto(visitorId = visitorId)
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/DataIntegrityViolationUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/DataIntegrityViolationUtils.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service
+
+import org.springframework.dao.DataIntegrityViolationException
+import java.sql.SQLException
+
+internal const val PERMITTED_PRISONER_BOOKER_PRISONER_UNIQUE_INDEX = "ux_permitted_prisoner_booker_prisoner"
+
+private const val POSTGRES_UNIQUE_VIOLATION_SQL_STATE = "23505"
+
+internal fun DataIntegrityViolationException.isUniqueViolationFor(constraintName: String): Boolean = sqlExceptions().any { sqlException ->
+    sqlException.sqlState == POSTGRES_UNIQUE_VIOLATION_SQL_STATE &&
+      sqlException.message?.contains(constraintName) == true
+  }
+
+private fun Throwable.sqlExceptions(): Sequence<SQLException> = sequence {
+  var cause: Throwable? = this@sqlExceptions
+  while (cause != null) {
+    if (cause is SQLException) {
+      yield(cause)
+
+      var nextException = cause.nextException
+      while (nextException != null) {
+        yield(nextException)
+        nextException = nextException.nextException
+      }
+    }
+
+    cause = cause.cause
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/DataIntegrityViolationUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/DataIntegrityViolationUtils.kt
@@ -8,9 +8,9 @@ internal const val PERMITTED_PRISONER_BOOKER_PRISONER_UNIQUE_INDEX = "ux_permitt
 private const val POSTGRES_UNIQUE_VIOLATION_SQL_STATE = "23505"
 
 internal fun DataIntegrityViolationException.isUniqueViolationFor(constraintName: String): Boolean = sqlExceptions().any { sqlException ->
-    sqlException.sqlState == POSTGRES_UNIQUE_VIOLATION_SQL_STATE &&
-      sqlException.message?.contains(constraintName) == true
-  }
+  sqlException.sqlState == POSTGRES_UNIQUE_VIOLATION_SQL_STATE &&
+    sqlException.message?.contains(constraintName) == true
+}
 
 private fun Throwable.sqlExceptions(): Sequence<SQLException> = sequence {
   var cause: Throwable? = this@sqlExceptions

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.Visito
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.BookerNotFoundException
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.PrisonerNotFoundException
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.VisitorRequestNotFoundException
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Booker
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.PermittedPrisoner
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.PermittedVisitor
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.VisitorRequest
@@ -52,7 +53,7 @@ class VisitorRequestsStoreService(
 
     // If we have a matching contact and there is only 1 of them, begin auto approval process.
     val visitorRequestStatus = if (matchingContact != null && !multipleMatches) {
-      val bookerPrisonerEntity = booker.permittedPrisoners.first { it.prisonerId == prisonerId }
+      val bookerPrisonerEntity = getPermittedPrisoner(booker, prisonerId)
 
       linkVisitorIfAbsent(bookerReference, prisonerId, bookerPrisonerEntity.id, bookerPrisonerEntity, matchingContact.personId!!)
 
@@ -75,7 +76,7 @@ class VisitorRequestsStoreService(
     )
 
     // Required for auditing purposes in calling service.
-    val prisonerRegisteredPrisonCode = booker.permittedPrisoners.first { it.prisonerId == prisonerId }.prisonCode
+    val prisonerRegisteredPrisonCode = getPermittedPrisoner(booker, prisonerId).prisonCode
 
     return CreateVisitorRequestResponseDto(
       reference = savedVisitorRequest.reference,
@@ -93,7 +94,7 @@ class VisitorRequestsStoreService(
     val booker = bookerRepository.findByReference(bookerReference)!!
 
     LOG.info("Enter VisitorRequestsApprovalStoreService approveAndLinkVisitor, booker reference - $bookerReference, prisonerId - $prisonerId, visitorId = $visitorId")
-    val bookerPrisoner = booker.permittedPrisoners.firstOrNull { it.prisonerId == prisonerId } ?: throw PrisonerNotFoundException("Booker with reference $bookerReference does not have a permitted prisoner with id $prisonerId")
+    val bookerPrisoner = getPermittedPrisoner(booker, prisonerId)
 
     linkVisitorIfAbsent(bookerReference, prisonerId, bookerPrisoner.id, bookerPrisoner, visitorId)
 
@@ -119,6 +120,10 @@ class VisitorRequestsStoreService(
   fun deleteVisitorRequestsByBookerPrisonerInStatusRequested(bookerReference: String, prisonerId: String) {
     visitorRequestsRepository.deleteVisitorRequestsByBookerReferenceAndPrisonerIdInStatusRequested(bookerReference, prisonerId)
   }
+
+  private fun getPermittedPrisoner(booker: Booker, prisonerId: String): PermittedPrisoner = booker.permittedPrisoners.firstOrNull {
+    it.prisonerId.equals(prisonerId, ignoreCase = true)
+  } ?: throw PrisonerNotFoundException("Booker with reference ${booker.reference} does not have a permitted prisoner with id $prisonerId")
 
   private fun linkVisitorIfAbsent(bookerReference: String, prisonerId: String, permittedPrisonerId: Long, permittedPrisoner: PermittedPrisoner, visitorId: Long) {
     if (visitorRepository.existsByPermittedPrisonerIdAndVisitorId(permittedPrisonerId, visitorId)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.Prison
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.VisitorRequestNotFoundException
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Booker
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.PermittedPrisoner
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.PermittedVisitor
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.VisitorRequest
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.BookerRepository
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.PermittedVisitorRepository
@@ -55,7 +54,7 @@ class VisitorRequestsStoreService(
     val visitorRequestStatus = if (matchingContact != null && !multipleMatches) {
       val bookerPrisonerEntity = getPermittedPrisoner(booker, prisonerId)
 
-      linkVisitorIfAbsent(bookerReference, prisonerId, bookerPrisonerEntity.id, bookerPrisonerEntity, matchingContact.personId!!)
+      linkVisitorIfAbsent(bookerReference, prisonerId, bookerPrisonerEntity.id, matchingContact.personId!!)
 
       AUTO_APPROVED
     } else {
@@ -96,7 +95,7 @@ class VisitorRequestsStoreService(
     LOG.info("Enter VisitorRequestsApprovalStoreService approveAndLinkVisitor, booker reference - $bookerReference, prisonerId - $prisonerId, visitorId = $visitorId")
     val bookerPrisoner = getPermittedPrisoner(booker, prisonerId)
 
-    linkVisitorIfAbsent(bookerReference, prisonerId, bookerPrisoner.id, bookerPrisoner, visitorId)
+    linkVisitorIfAbsent(bookerReference, prisonerId, bookerPrisoner.id, visitorId)
 
     val approvalStatus = if (autoApproval) {
       AUTO_APPROVED
@@ -125,18 +124,15 @@ class VisitorRequestsStoreService(
     it.prisonerId.equals(prisonerId, ignoreCase = true)
   } ?: throw PrisonerNotFoundException("Booker with reference ${booker.reference} does not have a permitted prisoner with id $prisonerId")
 
-  private fun linkVisitorIfAbsent(bookerReference: String, prisonerId: String, permittedPrisonerId: Long, permittedPrisoner: PermittedPrisoner, visitorId: Long) {
+  private fun linkVisitorIfAbsent(bookerReference: String, prisonerId: String, permittedPrisonerId: Long, visitorId: Long) {
     if (visitorRepository.existsByPermittedPrisonerIdAndVisitorId(permittedPrisonerId, visitorId)) {
       LOG.info("Visitor {} is already linked to booker {} prisoner {}, skipping duplicate permitted visitor insert", visitorId, bookerReference, prisonerId)
       return
     }
 
-    visitorRepository.saveAndFlush(
-      PermittedVisitor(
-        permittedPrisonerId = permittedPrisonerId,
-        permittedPrisoner = permittedPrisoner,
-        visitorId = visitorId,
-      ),
-    )
+    val insertedRows = visitorRepository.insertIfAbsent(permittedPrisonerId, visitorId)
+    if (insertedRows == 0) {
+      LOG.info("Visitor {} is already linked to booker {} prisoner {} after concurrent insert", visitorId, bookerReference, prisonerId)
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsStoreService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.Visito
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.BookerNotFoundException
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.PrisonerNotFoundException
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.VisitorRequestNotFoundException
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.PermittedPrisoner
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.PermittedVisitor
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.VisitorRequest
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.BookerRepository
@@ -53,13 +54,7 @@ class VisitorRequestsStoreService(
     val visitorRequestStatus = if (matchingContact != null && !multipleMatches) {
       val bookerPrisonerEntity = booker.permittedPrisoners.first { it.prisonerId == prisonerId }
 
-      visitorRepository.saveAndFlush(
-        PermittedVisitor(
-          permittedPrisonerId = bookerPrisonerEntity.id,
-          permittedPrisoner = bookerPrisonerEntity,
-          visitorId = matchingContact.personId!!,
-        ),
-      )
+      linkVisitorIfAbsent(bookerReference, prisonerId, bookerPrisonerEntity.id, bookerPrisonerEntity, matchingContact.personId!!)
 
       AUTO_APPROVED
     } else {
@@ -100,13 +95,7 @@ class VisitorRequestsStoreService(
     LOG.info("Enter VisitorRequestsApprovalStoreService approveAndLinkVisitor, booker reference - $bookerReference, prisonerId - $prisonerId, visitorId = $visitorId")
     val bookerPrisoner = booker.permittedPrisoners.firstOrNull { it.prisonerId == prisonerId } ?: throw PrisonerNotFoundException("Booker with reference $bookerReference does not have a permitted prisoner with id $prisonerId")
 
-    visitorRepository.saveAndFlush(
-      PermittedVisitor(
-        permittedPrisonerId = bookerPrisoner.id,
-        permittedPrisoner = bookerPrisoner,
-        visitorId = visitorId,
-      ),
-    )
+    linkVisitorIfAbsent(bookerReference, prisonerId, bookerPrisoner.id, bookerPrisoner, visitorId)
 
     val approvalStatus = if (autoApproval) {
       AUTO_APPROVED
@@ -129,5 +118,20 @@ class VisitorRequestsStoreService(
   @Transactional
   fun deleteVisitorRequestsByBookerPrisonerInStatusRequested(bookerReference: String, prisonerId: String) {
     visitorRequestsRepository.deleteVisitorRequestsByBookerReferenceAndPrisonerIdInStatusRequested(bookerReference, prisonerId)
+  }
+
+  private fun linkVisitorIfAbsent(bookerReference: String, prisonerId: String, permittedPrisonerId: Long, permittedPrisoner: PermittedPrisoner, visitorId: Long) {
+    if (visitorRepository.existsByPermittedPrisonerIdAndVisitorId(permittedPrisonerId, visitorId)) {
+      LOG.info("Visitor {} is already linked to booker {} prisoner {}, skipping duplicate permitted visitor insert", visitorId, bookerReference, prisonerId)
+      return
+    }
+
+    visitorRepository.saveAndFlush(
+      PermittedVisitor(
+        permittedPrisonerId = permittedPrisonerId,
+        permittedPrisoner = permittedPrisoner,
+        visitorId = visitorId,
+      ),
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/VisitorRequestsValidationService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.contact.regi
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.enums.VisitorRequestValidationError
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.exception.VisitorRequestValidationException
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Booker
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.PermittedPrisoner
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.VisitorRequest
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.VisitorRequestsRepository
 import java.time.LocalDate
@@ -38,7 +39,7 @@ class VisitorRequestsValidationService(
     val existingRequests = visitorRequestsRepository.findAllActiveRequestsByBookerReference(booker.reference)
 
     validateMaximumAllowedRequestsInProgress(booker, existingRequests)
-    validateDuplicateRequest(visitorRequest, existingRequests = existingRequests.filter { it.prisonerId == prisonerId })
+    validateDuplicateRequest(visitorRequest, existingRequests = existingRequests.filter { it.prisonerId.equals(prisonerId, ignoreCase = true) })
     validateVisitorAlreadyAdded(booker, prisonerId, visitorRequest, prisonerContactList)
 
     LOG.info("Successfully validated visitor request - For booker ${booker.reference}, prisoner $prisonerId")
@@ -102,7 +103,7 @@ class VisitorRequestsValidationService(
   }
 
   private fun validateBookerPrisonerRelationship(booker: Booker, prisonerId: String) {
-    if (!(booker.permittedPrisoners.any { it.prisonerId == prisonerId })) {
+    if (!(booker.permittedPrisoners.any { it.prisonerId.equals(prisonerId, ignoreCase = true) })) {
       LOG.error("Booker with reference ${booker.reference} does not have a permitted prisoner with id $prisonerId")
       throw VisitorRequestValidationException(VisitorRequestValidationError.PRISONER_NOT_FOUND_FOR_BOOKER)
     }
@@ -135,8 +136,7 @@ class VisitorRequestsValidationService(
   }
 
   private fun validateVisitorAlreadyAdded(booker: Booker, prisonerId: String, visitorRequest: AddVisitorToBookerPrisonerRequestDto, prisonerContactList: List<PrisonerContactDto>) {
-    val permittedVisitorIds = booker.permittedPrisoners
-      .first { it.prisonerId == prisonerId }
+    val permittedVisitorIds = getPermittedPrisoner(booker, prisonerId)
       .permittedVisitors
       .map { it.visitorId }
       .distinct()
@@ -156,4 +156,6 @@ class VisitorRequestsValidationService(
       throw VisitorRequestValidationException(VisitorRequestValidationError.VISITOR_ALREADY_EXISTS)
     }
   }
+
+  private fun getPermittedPrisoner(booker: Booker, prisonerId: String): PermittedPrisoner = booker.permittedPrisoners.first { it.prisonerId.equals(prisonerId, ignoreCase = true) }
 }

--- a/src/main/resources/db/migration/V2_7__add_permitted_relationship_unique_indexes.sql
+++ b/src/main/resources/db/migration/V2_7__add_permitted_relationship_unique_indexes.sql
@@ -1,0 +1,5 @@
+CREATE UNIQUE INDEX ux_permitted_prisoner_booker_prisoner
+ON permitted_prisoner (booker_id, lower(prisoner_id));
+
+CREATE UNIQUE INDEX ux_permitted_visitor_prisoner_visitor
+ON permitted_visitor (permitted_prisoner_id, visitor_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/ApproveVisitorRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/ApproveVisitorRequestTest.kt
@@ -128,6 +128,29 @@ class ApproveVisitorRequestTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `when approved visitor request prisoner id has different casing to stored prisoner the visitor is linked`() {
+    // Given
+    val prisonCode = "HEI"
+    val booker = createBooker("one-sub", "test@test.com")
+    val bookerReference = booker.reference
+    val prisoner = createPrisoner(booker, "AA123456", prisonCode)
+    val requestPrisonerId = prisoner.prisonerId.lowercase()
+    val visitorIdToBeLinked = 12345L
+    val request = createVisitorRequest(bookerReference, requestPrisonerId, AddVisitorToBookerPrisonerRequestDto("firstName1", "lastName1", LocalDate.now().minusYears(21)), status = REQUESTED)
+    val userName = "TEST-USER"
+
+    // When
+    val responseSpec = callApproveVisitorRequest(webTestClient, request.reference, visitorIdToBeLinked, userName, bookerConfigServiceRoleHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+
+    val permittedPrisoner = bookerRepository.findByReference(bookerReference)?.permittedPrisoners?.first { it.prisonerId == prisoner.prisonerId }
+    assertThat(permittedPrisoner!!.permittedVisitors.size).isEqualTo(1)
+    assertThat(permittedPrisoner.permittedVisitors[0].visitorId).isEqualTo(visitorIdToBeLinked)
+  }
+
+  @Test
   fun `when approve visitor request is called and booker does not exist then NOT_FOUND status is returned`() {
     // Given
     val visitorIdToBeLinked = 12345L

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/CreateBookerPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/CreateBookerPrisonerTest.kt
@@ -69,6 +69,35 @@ class CreateBookerPrisonerTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `when prisoner id is not normalised then prisoner is created with normalised prisoner id`() {
+    // Given
+    val normalisedPrisonerId = "AB123456"
+    val createPrisoner = CreatePermittedPrisonerDto(prisonerId = " ${normalisedPrisonerId.lowercase()} ", prisonCode = PRISON_CODE)
+
+    // When
+    val responseSpec = callCreateBookerPrisoner(bookerConfigServiceRoleHttpHeaders, createPrisoner, booker.reference)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+    val dto = getPermittedPrisonerDto(responseSpec)
+
+    assertThat(dto.prisonerId).isEqualTo(normalisedPrisonerId)
+
+    verify(bookerAuditRepositorySpy, times(1)).saveAndFlush(any<BookerAudit>())
+    verify(telemetryClientSpy, times(1)).trackEvent(
+      PRISONER_REGISTERED.telemetryEventName,
+      mapOf(
+        "bookerReference" to booker.reference,
+        "prisonerId" to normalisedPrisonerId,
+      ),
+      null,
+    )
+    val auditEvents = bookerAuditRepository.findAll()
+    assertThat(auditEvents).hasSize(1)
+    assertAuditEvent(auditEvents[0], booker.reference, PRISONER_REGISTERED, "Prisoner with prisonNumber - $normalisedPrisonerId registered against booker")
+  }
+
+  @Test
   fun `when prisoner already exist an exception is thrown`() {
     // Given
     val createPrisoner = CreatePermittedPrisonerDto(prisonerId = "1233", prisonCode = PRISON_CODE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/CreateBookerPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/CreateBookerPrisonerTest.kt
@@ -84,6 +84,23 @@ class CreateBookerPrisonerTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `when prisoner already exists with different casing an exception is thrown`() {
+    // Given
+    val existingPrisonerId = "AB123456"
+    val createPrisoner = CreatePermittedPrisonerDto(prisonerId = existingPrisonerId.lowercase(), prisonCode = PRISON_CODE)
+
+    val prisoner = createPrisoner(booker, existingPrisonerId)
+    booker.permittedPrisoners.add(prisoner)
+    bookerRepository.saveAndFlush(booker)
+
+    // When
+    val responseSpec = callCreateBookerPrisoner(bookerConfigServiceRoleHttpHeaders, createPrisoner, booker.reference)
+
+    // Then
+    assertError(responseSpec, "Booker prisoner already exists", "BookerPrisoner for ${booker.reference} already exists", BAD_REQUEST)
+  }
+
+  @Test
   fun `when booker not does exist then exception is thrown`() {
     // Given
     val createPrisoner = CreatePermittedPrisonerDto(prisonerId = "1233", prisonCode = PRISON_CODE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/SubmitVisitorRequestAddVisitorToBookerPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/SubmitVisitorRequestAddVisitorToBookerPrisonerTest.kt
@@ -123,6 +123,33 @@ class SubmitVisitorRequestAddVisitorToBookerPrisonerTest : IntegrationTestBase()
   }
 
   @Test
+  fun `when visitor request prisoner id has different casing to stored prisoner it is saved successfully with status auto_approved`() {
+    // Given
+    val booker = createBooker(oneLoginSub = "123", emailAddress = "test@test.come")
+    val prisoner = createPrisoner(booker, "AA123456")
+    val requestPrisonerId = prisoner.prisonerId.lowercase()
+    val visitorRequestDto = AddVisitorToBookerPrisonerRequestDto(
+      firstName = "John",
+      lastName = "Smith",
+      dateOfBirth = LocalDate.now().minusYears(21),
+      languagePreference = LanguagePreference.EN,
+    )
+
+    // When
+    val prisonerContact = PrisonerContactDto(personId = 543L, firstName = "John", lastName = "Smith", dateOfBirth = LocalDate.now().minusYears(21), approvedVisitor = true, contactType = "S")
+    prisonerContactRegistryMockServer.stubGetPrisonerSocialContacts(prisonerId = requestPrisonerId, listOf(prisonerContact))
+    val responseSpec = callSubmitVisitorRequest(bookerConfigServiceRoleHttpHeaders, booker.reference, requestPrisonerId, visitorRequestDto)
+
+    // Then
+    responseSpec.expectStatus().isCreated
+
+    val visitorRequests = visitorRequestsRepository.findAll()
+    assertThat(visitorRequests).hasSize(1)
+    assertVisitorRequest(visitorRequests[0], booker.reference, requestPrisonerId, visitorRequestDto, VisitorRequestsStatus.AUTO_APPROVED, personId = prisonerContact.personId)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(prisonerId = requestPrisonerId)
+  }
+
+  @Test
   fun `when visitor request comes in and the only matching contact is an unapproved visitor then request is still matched and saved to database with status auto_approved`() {
     // Given
     val booker = createBooker(oneLoginSub = "123", emailAddress = "test@test.come")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/UnlinkVisitorByPrisonerIdAndBookerReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/UnlinkVisitorByPrisonerIdAndBookerReferenceTest.kt
@@ -73,7 +73,7 @@ class UnlinkVisitorByPrisonerIdAndBookerReferenceTest : IntegrationTestBase() {
 
     bookerTwo = createBooker(oneLoginSub = "987", emailAddress = "test-two@example.com")
     val prisonersForBookerTwo = createAssociatedPrisoners(
-      booker,
+      bookerTwo,
       listOf(
         PermittedPrisonerTestObject("AB123456", PRISON_CODE),
         PermittedPrisonerTestObject("DD948472", PRISON_CODE),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/UnlinkVisitorByPrisonerIdAndBookerReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/UnlinkVisitorByPrisonerIdAndBookerReferenceTest.kt
@@ -125,6 +125,21 @@ class UnlinkVisitorByPrisonerIdAndBookerReferenceTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `when prisoner id has different casing to stored prisoner then visitor is unlinked successfully`() {
+    // Given
+    val actionedByDto = ActionedByDto(actionedBy = "test-user")
+
+    // When
+    val responseSpec = unlinkVisitorByPrisonerIdAndBookerReference(webTestClient, booker.reference, prisoner.prisonerId.lowercase(), visitor1.visitorId, actionedByDto, bookerConfigServiceRoleHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+
+    val visitors = permittedVisitorRepository.findAll()
+    assertThat(visitors).hasSize(3)
+  }
+
+  @Test
   fun `when invalid reference then NOT_FOUND status is returned`() {
     // Given
     val actionedByDto = ActionedByDto(actionedBy = "test-user")


### PR DESCRIPTION
## What does this PR do?
Enforce more strict duplicate restrictions on both DB level and API level, to ensure a prisoner cannot be added to the same booker twice, and a visitor cannot be added to the same booker's prisoner twice.

Add DB level constraint on both.

update flows through API which could have allowed duplicates
- Remove case sensitivity on prisoner adding
- Add DB level check before auto approving or approving visitor request and adding visitor

Updated tests for coverage

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-3876
https://dsdmoj.atlassian.net/browse/VB-6703