### PR TITLE
VB-6829 - Manual prisoner merging

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/controller/admin/PrisonerMergeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/controller/admin/PrisonerMergeController.kt
@@ -14,14 +14,14 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeBatchRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeRequestDto
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.PrisonerMergeService
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.ManualPrisonerMergeService
 
 const val PRISONER_MERGE_PATH: String = "/public/prisoner/merge"
 const val PRISONER_MERGE_BATCH_PATH: String = "$PRISONER_MERGE_PATH/batch"
 
 @RestController
 class PrisonerMergeController(
-  private val prisonerMergeService: PrisonerMergeService,
+  private val manualPrisonerMergeService: ManualPrisonerMergeService,
 ) {
   @PreAuthorize("hasRole('ROLE_VISIT_BOOKER_REGISTRY__VISIT_BOOKER_CONFIG')")
   @PostMapping(PRISONER_MERGE_PATH)
@@ -55,7 +55,7 @@ class PrisonerMergeController(
     @RequestBody
     @Valid
     prisonerMergeRequestDto: PrisonerMergeRequestDto,
-  ) = prisonerMergeService.mergePrisoner(
+  ) = manualPrisonerMergeService.mergePrisoner(
     oldPrisonerNumber = prisonerMergeRequestDto.oldPrisonerNumber,
     newPrisonerNumber = prisonerMergeRequestDto.newPrisonerNumber,
   )
@@ -92,12 +92,5 @@ class PrisonerMergeController(
     @RequestBody
     @Valid
     prisonerMergeBatchRequestDto: PrisonerMergeBatchRequestDto,
-  ) {
-    prisonerMergeBatchRequestDto.prisonerMerges.forEach {
-      prisonerMergeService.mergePrisoner(
-        oldPrisonerNumber = it.oldPrisonerNumber,
-        newPrisonerNumber = it.newPrisonerNumber,
-      )
-    }
-  }
+  ) = manualPrisonerMergeService.mergePrisoners(prisonerMergeBatchRequestDto.prisonerMerges)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/controller/admin/PrisonerMergeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/controller/admin/PrisonerMergeController.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.controller.admin
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeBatchRequestDto
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeRequestDto
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.PrisonerMergeService
+
+const val PRISONER_MERGE_PATH: String = "/public/prisoner/merge"
+const val PRISONER_MERGE_BATCH_PATH: String = "$PRISONER_MERGE_PATH/batch"
+
+@RestController
+class PrisonerMergeController(
+  private val prisonerMergeService: PrisonerMergeService,
+) {
+  @PreAuthorize("hasRole('ROLE_VISIT_BOOKER_REGISTRY__VISIT_BOOKER_CONFIG')")
+  @PostMapping(PRISONER_MERGE_PATH)
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Manually merge a prisoner number",
+    description = "Updates records from an old prisoner number to a new prisoner number.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Prisoner number merge processed",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect request to merge a prisoner number",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to merge a prisoner number",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun mergePrisoner(
+    @RequestBody
+    @Valid
+    prisonerMergeRequestDto: PrisonerMergeRequestDto,
+  ) = prisonerMergeService.mergePrisoner(
+    oldPrisonerNumber = prisonerMergeRequestDto.oldPrisonerNumber,
+    newPrisonerNumber = prisonerMergeRequestDto.newPrisonerNumber,
+  )
+
+  @PreAuthorize("hasRole('ROLE_VISIT_BOOKER_REGISTRY__VISIT_BOOKER_CONFIG')")
+  @PostMapping(PRISONER_MERGE_BATCH_PATH)
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Manually merge prisoner numbers in a batch",
+    description = "Processes each prisoner number merge in its own transaction.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Prisoner number merges processed",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect request to merge prisoner numbers",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to merge prisoner numbers",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun mergePrisoners(
+    @RequestBody
+    @Valid
+    prisonerMergeBatchRequestDto: PrisonerMergeBatchRequestDto,
+  ) {
+    prisonerMergeBatchRequestDto.prisonerMerges.forEach {
+      prisonerMergeService.mergePrisoner(
+        oldPrisonerNumber = it.oldPrisonerNumber,
+        newPrisonerNumber = it.newPrisonerNumber,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/PrisonerMergeRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/dto/PrisonerMergeRequestDto.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto
+
+import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+
+@Schema(description = "Prisoner merge request with old and new prisoner numbers.")
+data class PrisonerMergeRequestDto(
+  @param:JsonProperty("oldPrisonerNumber")
+  @param:JsonAlias("removedNomsNumber")
+  @param:Schema(description = "Old prisoner number to replace.", example = "A1234AA", required = true)
+  @field:NotBlank
+  val oldPrisonerNumber: String,
+
+  @param:JsonProperty("newPrisonerNumber")
+  @param:JsonAlias("nomsNumber")
+  @param:Schema(description = "New prisoner number to update records to.", example = "B1234BB", required = true)
+  @field:NotBlank
+  val newPrisonerNumber: String,
+)
+
+@Schema(description = "Batch prisoner merge request.")
+data class PrisonerMergeBatchRequestDto(
+  @param:JsonProperty("prisonerMerges")
+  @param:Schema(description = "Prisoner merges to process.", required = true)
+  @field:NotEmpty
+  @field:Valid
+  val prisonerMerges: List<PrisonerMergeRequestDto>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/ManualPrisonerMergeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/ManualPrisonerMergeService.kt
@@ -4,7 +4,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeRequestDto
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.PrisonerMergeService.Companion.MERGE_EVENT_FAILED_FOR_BOOKER
 
 @Service
 class ManualPrisonerMergeService(
@@ -13,6 +12,7 @@ class ManualPrisonerMergeService(
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+    private const val MANUAL_MERGE_EVENT_FAILED_FOR_PRISONER = "manual_prisoner_merge_event_failed"
   }
 
   fun mergePrisoner(oldPrisonerNumber: String, newPrisonerNumber: String) {
@@ -34,7 +34,7 @@ class ManualPrisonerMergeService(
     } catch (e: Exception) {
       LOG.error("Failed to manually merge prisoner number from {} to {}", oldPrisonerNumber, newPrisonerNumber, e)
       telemetryClientService.trackEvent(
-        MERGE_EVENT_FAILED_FOR_BOOKER,
+        MANUAL_MERGE_EVENT_FAILED_FOR_PRISONER,
         mapOf(
           "oldPrisonerNumber" to oldPrisonerNumber,
           "newPrisonerNumber" to newPrisonerNumber,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/ManualPrisonerMergeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/ManualPrisonerMergeService.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeRequestDto
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.PrisonerMergeService.Companion.MERGE_EVENT_FAILED_FOR_BOOKER
+
+@Service
+class ManualPrisonerMergeService(
+  private val prisonerMergeService: PrisonerMergeService,
+  private val telemetryClientService: TelemetryClientService,
+) {
+  companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun mergePrisoner(oldPrisonerNumber: String, newPrisonerNumber: String) {
+    prisonerMergeService.mergePrisoner(oldPrisonerNumber, newPrisonerNumber)
+  }
+
+  fun mergePrisoners(prisonerMerges: List<PrisonerMergeRequestDto>) {
+    prisonerMerges.forEach {
+      mergePrisonerAndLogFailure(
+        oldPrisonerNumber = it.oldPrisonerNumber,
+        newPrisonerNumber = it.newPrisonerNumber,
+      )
+    }
+  }
+
+  private fun mergePrisonerAndLogFailure(oldPrisonerNumber: String, newPrisonerNumber: String) {
+    try {
+      prisonerMergeService.mergePrisoner(oldPrisonerNumber, newPrisonerNumber)
+    } catch (e: Exception) {
+      LOG.error("Failed to manually merge prisoner number from {} to {}", oldPrisonerNumber, newPrisonerNumber, e)
+      telemetryClientService.trackEvent(
+        MERGE_EVENT_FAILED_FOR_BOOKER,
+        mapOf(
+          "oldPrisonerNumber" to oldPrisonerNumber,
+          "newPrisonerNumber" to newPrisonerNumber,
+          "exceptionType" to e::class.java.name,
+          "exceptionMessage" to (e.message ?: ""),
+        ),
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/PrisonerMergeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/PrisonerMergeService.kt
@@ -17,7 +17,7 @@ class PrisonerMergeService(
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
-    internal const val MERGE_EVENT_FAILED_FOR_BOOKER = "booker_merge_event_failed"
+    private const val MERGE_EVENT_FAILED_FOR_BOOKER = "booker_merge_event_failed"
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/PrisonerMergeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/PrisonerMergeService.kt
@@ -17,7 +17,7 @@ class PrisonerMergeService(
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
-    private const val MERGE_EVENT_FAILED_FOR_BOOKER = "booker_merge_event_failed"
+    const val MERGE_EVENT_FAILED_FOR_BOOKER = "booker_merge_event_failed"
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/PrisonerMergeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/service/PrisonerMergeService.kt
@@ -17,7 +17,7 @@ class PrisonerMergeService(
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
-    const val MERGE_EVENT_FAILED_FOR_BOOKER = "booker_merge_event_failed"
+    internal const val MERGE_EVENT_FAILED_FOR_BOOKER = "booker_merge_event_failed"
   }
 
   @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/PrisonerMergeControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/PrisonerMergeControllerTest.kt
@@ -1,13 +1,15 @@
 package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration
 
+import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 import org.springframework.transaction.annotation.Propagation.SUPPORTS
@@ -18,7 +20,7 @@ import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.controller.admin
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeBatchRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeRequestDto
 import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Booker
-import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.PrisonerMergeService
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.repository.PermittedPrisonerRepository
 
 @Transactional(propagation = SUPPORTS)
 @DisplayName("Manual prisoner merge controller tests")
@@ -28,7 +30,10 @@ class PrisonerMergeControllerTest : IntegrationTestBase() {
   private lateinit var booker3: Booker
 
   @MockitoSpyBean
-  private lateinit var prisonerMergeServiceSpy: PrisonerMergeService
+  private lateinit var telemetryClientSpy: TelemetryClient
+
+  @MockitoSpyBean
+  private lateinit var permittedPrisonerRepositorySpy: PermittedPrisonerRepository
 
   @BeforeEach
   internal fun setUp() {
@@ -129,24 +134,28 @@ class PrisonerMergeControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when manual prisoner merge batch fails halfway then previous merge remains committed`() {
+  fun `when manual prisoner merge batch fails halfway then failure is logged and remaining merges continue`() {
     // Given
     val successfulOldPrisonerNumber = "AB123XYZ"
     val successfulNewPrisonerNumber = "BB123ABC"
     val failingOldPrisonerNumber = "FAILOLD"
     val failingNewPrisonerNumber = "FAILNEW"
+    val nextSuccessfulOldPrisonerNumber = "CB123XYZ"
+    val nextSuccessfulNewPrisonerNumber = "DB123ABC"
 
     createAssociatedPrisoners(booker1, listOf(PermittedPrisonerTestObject(successfulOldPrisonerNumber, PRISON_CODE)))
     createAssociatedPrisoners(booker2, listOf(PermittedPrisonerTestObject(failingOldPrisonerNumber, PRISON_CODE)))
+    createAssociatedPrisoners(booker3, listOf(PermittedPrisonerTestObject(nextSuccessfulOldPrisonerNumber, PRISON_CODE)))
 
     doThrow(RuntimeException("Batch merge failure"))
-      .whenever(prisonerMergeServiceSpy)
-      .mergePrisoner(failingOldPrisonerNumber, failingNewPrisonerNumber)
+      .whenever(permittedPrisonerRepositorySpy)
+      .mergePrisoner(oldPrisonerId = failingOldPrisonerNumber, newPrisonerId = failingNewPrisonerNumber)
 
     val request = PrisonerMergeBatchRequestDto(
       prisonerMerges = listOf(
         PrisonerMergeRequestDto(oldPrisonerNumber = successfulOldPrisonerNumber, newPrisonerNumber = successfulNewPrisonerNumber),
         PrisonerMergeRequestDto(oldPrisonerNumber = failingOldPrisonerNumber, newPrisonerNumber = failingNewPrisonerNumber),
+        PrisonerMergeRequestDto(oldPrisonerNumber = nextSuccessfulOldPrisonerNumber, newPrisonerNumber = nextSuccessfulNewPrisonerNumber),
       ),
     )
 
@@ -154,10 +163,22 @@ class PrisonerMergeControllerTest : IntegrationTestBase() {
     val responseSpec = callMergePrisoners(bookerConfigServiceRoleHttpHeaders, request)
 
     // Then
-    responseSpec.expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+    responseSpec.expectStatus().isOk
 
     assertThat(prisonerIdsForBooker(booker1)).containsExactly(successfulNewPrisonerNumber)
     assertThat(prisonerIdsForBooker(booker2)).containsExactly(failingOldPrisonerNumber)
+    assertThat(prisonerIdsForBooker(booker3)).containsExactly(nextSuccessfulNewPrisonerNumber)
+
+    verify(telemetryClientSpy, times(1)).trackEvent(
+      "booker_merge_event_failed",
+      mapOf(
+        "oldPrisonerNumber" to failingOldPrisonerNumber,
+        "newPrisonerNumber" to failingNewPrisonerNumber,
+        "exceptionType" to RuntimeException::class.java.name,
+        "exceptionMessage" to "Batch merge failure",
+      ),
+      null,
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/PrisonerMergeControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/PrisonerMergeControllerTest.kt
@@ -1,0 +1,210 @@
+package uk.gov.justice.digital.hmpps.prison.visitbooker.registry.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
+import org.springframework.transaction.annotation.Propagation.SUPPORTS
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.controller.admin.PRISONER_MERGE_BATCH_PATH
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.controller.admin.PRISONER_MERGE_PATH
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeBatchRequestDto
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.dto.PrisonerMergeRequestDto
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.model.entity.Booker
+import uk.gov.justice.digital.hmpps.prison.visitbooker.registry.service.PrisonerMergeService
+
+@Transactional(propagation = SUPPORTS)
+@DisplayName("Manual prisoner merge controller tests")
+class PrisonerMergeControllerTest : IntegrationTestBase() {
+  private lateinit var booker1: Booker
+  private lateinit var booker2: Booker
+  private lateinit var booker3: Booker
+
+  @MockitoSpyBean
+  private lateinit var prisonerMergeServiceSpy: PrisonerMergeService
+
+  @BeforeEach
+  internal fun setUp() {
+    booker1 = createBooker(oneLoginSub = "123", emailAddress = "test@example.com")
+    booker2 = createBooker(oneLoginSub = "456", emailAddress = "test1@example.com")
+    booker3 = createBooker(oneLoginSub = "789", emailAddress = "test2@example.com")
+  }
+
+  @Test
+  fun `when manual prisoner merge is requested then old prisoner number is updated with new prisoner number`() {
+    // Given
+    val oldPrisonerNumber = "AB123XYZ"
+    val newPrisonerNumber = "BB123ABC"
+    val otherPrisonerNumber = "OTH123"
+
+    createAssociatedPrisoners(
+      booker1,
+      listOf(
+        PermittedPrisonerTestObject(oldPrisonerNumber, PRISON_CODE),
+        PermittedPrisonerTestObject(otherPrisonerNumber, PRISON_CODE),
+      ),
+    )
+    createAssociatedPrisoners(booker2, listOf(PermittedPrisonerTestObject(oldPrisonerNumber, PRISON_CODE)))
+    createAssociatedPrisoners(booker3, listOf(PermittedPrisonerTestObject(otherPrisonerNumber, PRISON_CODE)))
+
+    val request = PrisonerMergeRequestDto(
+      oldPrisonerNumber = oldPrisonerNumber,
+      newPrisonerNumber = newPrisonerNumber,
+    )
+
+    // When
+    val responseSpec = callMergePrisoner(bookerConfigServiceRoleHttpHeaders, request)
+
+    // Then
+    responseSpec.expectStatus().isOk
+
+    assertThat(prisonerIdsForBooker(booker1)).containsExactlyInAnyOrder(newPrisonerNumber, otherPrisonerNumber)
+    assertThat(prisonerIdsForBooker(booker2)).containsExactly(newPrisonerNumber)
+    assertThat(prisonerIdsForBooker(booker3)).containsExactly(otherPrisonerNumber)
+  }
+
+  @Test
+  fun `when manual prisoner merge is requested with event field names then old prisoner number is updated`() {
+    // Given
+    val oldPrisonerNumber = "AB123XYZ"
+    val newPrisonerNumber = "BB123ABC"
+
+    createAssociatedPrisoners(booker1, listOf(PermittedPrisonerTestObject(oldPrisonerNumber, PRISON_CODE)))
+
+    val request = mapOf(
+      "removedNomsNumber" to oldPrisonerNumber,
+      "nomsNumber" to newPrisonerNumber,
+    )
+
+    // When
+    val responseSpec = callMergePrisoner(bookerConfigServiceRoleHttpHeaders, request)
+
+    // Then
+    responseSpec.expectStatus().isOk
+
+    assertThat(prisonerIdsForBooker(booker1)).containsExactly(newPrisonerNumber)
+  }
+
+  @Test
+  fun `when manual prisoner merge batch is requested then each old prisoner number is updated`() {
+    // Given
+    val oldPrisonerNumber1 = "AB123XYZ"
+    val newPrisonerNumber1 = "BB123ABC"
+    val oldPrisonerNumber2 = "CB123XYZ"
+    val newPrisonerNumber2 = "DB123ABC"
+
+    createAssociatedPrisoners(
+      booker1,
+      listOf(
+        PermittedPrisonerTestObject(oldPrisonerNumber1, PRISON_CODE),
+        PermittedPrisonerTestObject(oldPrisonerNumber2, PRISON_CODE),
+      ),
+    )
+    createAssociatedPrisoners(booker2, listOf(PermittedPrisonerTestObject(oldPrisonerNumber1, PRISON_CODE)))
+    createAssociatedPrisoners(booker3, listOf(PermittedPrisonerTestObject(oldPrisonerNumber2, PRISON_CODE)))
+
+    val request = PrisonerMergeBatchRequestDto(
+      prisonerMerges = listOf(
+        PrisonerMergeRequestDto(oldPrisonerNumber = oldPrisonerNumber1, newPrisonerNumber = newPrisonerNumber1),
+        PrisonerMergeRequestDto(oldPrisonerNumber = oldPrisonerNumber2, newPrisonerNumber = newPrisonerNumber2),
+      ),
+    )
+
+    // When
+    val responseSpec = callMergePrisoners(bookerConfigServiceRoleHttpHeaders, request)
+
+    // Then
+    responseSpec.expectStatus().isOk
+
+    assertThat(prisonerIdsForBooker(booker1)).containsExactlyInAnyOrder(newPrisonerNumber1, newPrisonerNumber2)
+    assertThat(prisonerIdsForBooker(booker2)).containsExactly(newPrisonerNumber1)
+    assertThat(prisonerIdsForBooker(booker3)).containsExactly(newPrisonerNumber2)
+  }
+
+  @Test
+  fun `when manual prisoner merge batch fails halfway then previous merge remains committed`() {
+    // Given
+    val successfulOldPrisonerNumber = "AB123XYZ"
+    val successfulNewPrisonerNumber = "BB123ABC"
+    val failingOldPrisonerNumber = "FAILOLD"
+    val failingNewPrisonerNumber = "FAILNEW"
+
+    createAssociatedPrisoners(booker1, listOf(PermittedPrisonerTestObject(successfulOldPrisonerNumber, PRISON_CODE)))
+    createAssociatedPrisoners(booker2, listOf(PermittedPrisonerTestObject(failingOldPrisonerNumber, PRISON_CODE)))
+
+    doThrow(RuntimeException("Batch merge failure"))
+      .whenever(prisonerMergeServiceSpy)
+      .mergePrisoner(failingOldPrisonerNumber, failingNewPrisonerNumber)
+
+    val request = PrisonerMergeBatchRequestDto(
+      prisonerMerges = listOf(
+        PrisonerMergeRequestDto(oldPrisonerNumber = successfulOldPrisonerNumber, newPrisonerNumber = successfulNewPrisonerNumber),
+        PrisonerMergeRequestDto(oldPrisonerNumber = failingOldPrisonerNumber, newPrisonerNumber = failingNewPrisonerNumber),
+      ),
+    )
+
+    // When
+    val responseSpec = callMergePrisoners(bookerConfigServiceRoleHttpHeaders, request)
+
+    // Then
+    responseSpec.expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+
+    assertThat(prisonerIdsForBooker(booker1)).containsExactly(successfulNewPrisonerNumber)
+    assertThat(prisonerIdsForBooker(booker2)).containsExactly(failingOldPrisonerNumber)
+  }
+
+  @Test
+  fun `when manual prisoner merge is called with incorrect role then forbidden is returned`() {
+    // Given
+    val request = PrisonerMergeRequestDto(
+      oldPrisonerNumber = "AB123XYZ",
+      newPrisonerNumber = "BB123ABC",
+    )
+
+    // When
+    val responseSpec = callMergePrisoner(orchestrationServiceRoleHttpHeaders, request)
+
+    // Then
+    responseSpec.expectStatus().isForbidden
+  }
+
+  @Test
+  fun `when manual prisoner merge is called with invalid request then bad request is returned`() {
+    // Given
+    val request = PrisonerMergeRequestDto(
+      oldPrisonerNumber = "",
+      newPrisonerNumber = "BB123ABC",
+    )
+
+    // When
+    val responseSpec = callMergePrisoner(bookerConfigServiceRoleHttpHeaders, request)
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+  }
+
+  private fun prisonerIdsForBooker(booker: Booker): List<String> = permittedPrisonerRepository.findByBookerId(booker.id).map { it.prisonerId }
+
+  private fun callMergePrisoner(
+    authHttpHeaders: (HttpHeaders) -> Unit,
+    request: Any,
+  ): ResponseSpec = webTestClient.post().uri(PRISONER_MERGE_PATH)
+    .headers(authHttpHeaders)
+    .body(BodyInserters.fromValue(request))
+    .exchange()
+
+  private fun callMergePrisoners(
+    authHttpHeaders: (HttpHeaders) -> Unit,
+    request: PrisonerMergeBatchRequestDto,
+  ): ResponseSpec = webTestClient.post().uri(PRISONER_MERGE_BATCH_PATH)
+    .headers(authHttpHeaders)
+    .body(BodyInserters.fromValue(request))
+    .exchange()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/PrisonerMergeControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prison/visitbooker/registry/integration/PrisonerMergeControllerTest.kt
@@ -170,7 +170,7 @@ class PrisonerMergeControllerTest : IntegrationTestBase() {
     assertThat(prisonerIdsForBooker(booker3)).containsExactly(nextSuccessfulNewPrisonerNumber)
 
     verify(telemetryClientSpy, times(1)).trackEvent(
-      "booker_merge_event_failed",
+      "manual_prisoner_merge_event_failed",
       mapOf(
         "oldPrisonerNumber" to failingOldPrisonerNumber,
         "newPrisonerNumber" to failingNewPrisonerNumber,


### PR DESCRIPTION
## What does this PR do?
Historical prisoner merges are no longer on our SQS. We need a way to manually merge either a single pair of prisoner Ids or a list of paired prisonerIds.

Add new logic to handle manual merging. Also add to the bulk merge endpoint, logic to handle individual failures without failing the entire API call (log failures to app insights for manual monitoring).

Add tests to cover flow.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-6353
https://dsdmoj.atlassian.net/browse/VB-6829